### PR TITLE
Change syntax of array initialization

### DIFF
--- a/src/main/gen/com/spicelang/intellij/spice/SpiceParser.java
+++ b/src/main/gen/com/spicelang/intellij/spice/SpiceParser.java
@@ -184,15 +184,15 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // LBRACE argLst? RBRACE
+  // LBRACKET argLst? RBRACKET
   public static boolean arrayInitialization(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "arrayInitialization")) return false;
-    if (!nextTokenIs(b, LBRACE)) return false;
+    if (!nextTokenIs(b, LBRACKET)) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = consumeToken(b, LBRACE);
+    r = consumeToken(b, LBRACKET);
     r = r && arrayInitialization_1(b, l + 1);
-    r = r && consumeToken(b, RBRACE);
+    r = r && consumeToken(b, RBRACKET);
     exit_section_(b, m, ARRAY_INITIALIZATION, r);
     return r;
   }

--- a/src/main/java/com/spicelang/intellij/spice/Spice.bnf
+++ b/src/main/java/com/spicelang/intellij/spice/Spice.bnf
@@ -100,7 +100,7 @@ atomicExpr ::= value | (identifierExpr SCOPE_ACCESS)* identifierExpr | builtinCa
 value ::= constant | functionCall | arrayInitialization | structInstantiation | lambda | NIL LESS dataType GREATER
 constant ::= DOUBLE_LIT | INT_LIT | SHORT_LIT | LONG_LIT | CHAR_LIT | STRING_LIT | TRUE | FALSE
 functionCall ::= (IDENTIFIER SCOPE_ACCESS)* (IDENTIFIER DOT)* identifierExpr (LESS typeLst GREATER)? LPAREN argLst? RPAREN
-arrayInitialization ::= LBRACE argLst? RBRACE
+arrayInitialization ::= LBRACKET argLst? RBRACKET
 structInstantiation ::= (IDENTIFIER SCOPE_ACCESS)* TYPE_IDENTIFIER (LESS typeLst GREATER)? LBRACE argLst? RBRACE
 lambda ::= LPAREN paramLst? RPAREN ARROW (assignExpr | dataType? LBRACE stmtLst RBRACE)
 


### PR DESCRIPTION
Change syntax of array initialization from `{item1, item2, item3}` to `[item1, item2, item3]`