### PR TITLE
Allow upper case ext def names

### DIFF
--- a/src/main/gen/com/spicelang/intellij/spice/SpiceParser.java
+++ b/src/main/gen/com/spicelang/intellij/spice/SpiceParser.java
@@ -971,7 +971,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // fctAttr? EXT (F LESS dataType GREATER | P) IDENTIFIER LPAREN (typeLst ELLIPSIS?)? RPAREN SEMICOLON
+  // fctAttr? EXT (F LESS dataType GREATER | P) (IDENTIFIER | TYPE_IDENTIFIER) LPAREN (typeLst ELLIPSIS?)? RPAREN SEMICOLON
   public static boolean extDecl(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "extDecl")) return false;
     if (!nextTokenIs(b, "<ext decl>", EXT, FCT_ATTR_PREAMBLE)) return false;
@@ -980,7 +980,8 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     r = extDecl_0(b, l + 1);
     r = r && consumeToken(b, EXT);
     r = r && extDecl_2(b, l + 1);
-    r = r && consumeTokens(b, 0, IDENTIFIER, LPAREN);
+    r = r && extDecl_3(b, l + 1);
+    r = r && consumeToken(b, LPAREN);
     r = r && extDecl_5(b, l + 1);
     r = r && consumeTokens(b, 0, RPAREN, SEMICOLON);
     exit_section_(b, l, m, r, false, null);
@@ -1014,6 +1015,15 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     r = r && dataType(b, l + 1);
     r = r && consumeToken(b, GREATER);
     exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // IDENTIFIER | TYPE_IDENTIFIER
+  private static boolean extDecl_3(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "extDecl_3")) return false;
+    boolean r;
+    r = consumeToken(b, IDENTIFIER);
+    if (!r) r = consumeToken(b, TYPE_IDENTIFIER);
     return r;
   }
 

--- a/src/main/java/com/spicelang/intellij/spice/Spice.bnf
+++ b/src/main/java/com/spicelang/intellij/spice/Spice.bnf
@@ -33,7 +33,7 @@ enumDef ::= specifierLst? TYPE TYPE_IDENTIFIER ENUM LBRACE enumItemLst RBRACE
 genericTypeDef ::= TYPE TYPE_IDENTIFIER typeAltsLst SEMICOLON
 aliasDef ::= specifierLst? TYPE TYPE_IDENTIFIER ALIAS dataType SEMICOLON
 globalVarDef ::= dataType TYPE_IDENTIFIER (ASSIGN MINUS? value)? SEMICOLON
-extDecl ::= fctAttr? EXT (F LESS dataType GREATER | P) IDENTIFIER LPAREN (typeLst ELLIPSIS?)? RPAREN SEMICOLON
+extDecl ::= fctAttr? EXT (F LESS dataType GREATER | P) (IDENTIFIER | TYPE_IDENTIFIER) LPAREN (typeLst ELLIPSIS?)? RPAREN SEMICOLON
 
 // Control structures
 unsafeBlockDef ::= UNSAFE LBRACE stmtLst RBRACE


### PR DESCRIPTION
Allow upper case ext def names. This is required for the Win32 API