### PR TITLE
Add brace matcher and brace-aware indentation

### DIFF
--- a/src/main/java/com/spicelang/intellij/spice/SpiceBlock.java
+++ b/src/main/java/com/spicelang/intellij/spice/SpiceBlock.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice;
+
+import com.intellij.formatting.Alignment;
+import com.intellij.formatting.Block;
+import com.intellij.formatting.ChildAttributes;
+import com.intellij.formatting.Indent;
+import com.intellij.formatting.Spacing;
+import com.intellij.formatting.Wrap;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.TokenType;
+import com.intellij.psi.formatter.common.AbstractBlock;
+import com.intellij.psi.tree.IElementType;
+import com.spicelang.intellij.spice.psi.SpiceTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SpiceBlock extends AbstractBlock {
+
+    protected SpiceBlock(@NotNull ASTNode node, @Nullable Wrap wrap, @Nullable Alignment alignment) {
+        super(node, wrap, alignment);
+    }
+
+    @Override
+    protected List<Block> buildChildren() {
+        List<Block> blocks = new ArrayList<>();
+        for (ASTNode child = myNode.getFirstChildNode(); child != null; child = child.getTreeNext()) {
+            if (child.getElementType() == TokenType.WHITE_SPACE) continue;
+            if (child.getText().isBlank()) continue;
+            blocks.add(new SpiceBlock(child, null, null));
+        }
+        return blocks;
+    }
+
+    @Override
+    public Indent getIndent() {
+        ASTNode parent = myNode.getTreeParent();
+        IElementType parentType = parent != null ? parent.getElementType() : null;
+        IElementType type = myNode.getElementType();
+        // Indent everything that lives directly inside a brace block, except the braces themselves.
+        if (isBlockBody(parentType) && type != SpiceTypes.LBRACE && type != SpiceTypes.RBRACE) {
+            return Indent.getNormalIndent();
+        }
+        return Indent.getNoneIndent();
+    }
+
+    @NotNull
+    @Override
+    public ChildAttributes getChildAttributes(int newChildIndex) {
+        // Drives the indent of a freshly created line, e.g. after pressing Enter behind an opening brace.
+        if (isBlockBody(myNode.getElementType())) {
+            return new ChildAttributes(Indent.getNormalIndent(), null);
+        }
+        return new ChildAttributes(Indent.getNoneIndent(), null);
+    }
+
+    @Nullable
+    @Override
+    public Spacing getSpacing(@Nullable Block child1, @NotNull Block child2) {
+        return null;
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return myNode.getFirstChildNode() == null;
+    }
+
+    private static boolean isBlockBody(@Nullable IElementType type) {
+        return type == SpiceTypes.STMT_LST
+                || type == SpiceTypes.STRUCT_DEF
+                || type == SpiceTypes.INTERFACE_DEF
+                || type == SpiceTypes.ENUM_DEF;
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/SpiceBraceMatcher.java
+++ b/src/main/java/com/spicelang/intellij/spice/SpiceBraceMatcher.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice;
+
+import com.intellij.lang.BracePair;
+import com.intellij.lang.PairedBraceMatcher;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IElementType;
+import com.spicelang.intellij.spice.psi.SpiceTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SpiceBraceMatcher implements PairedBraceMatcher {
+
+    private static final BracePair[] PAIRS = new BracePair[]{
+            new BracePair(SpiceTypes.LBRACE, SpiceTypes.RBRACE, true),
+            new BracePair(SpiceTypes.LPAREN, SpiceTypes.RPAREN, false),
+            new BracePair(SpiceTypes.LBRACKET, SpiceTypes.RBRACKET, false),
+    };
+
+    @Override
+    public BracePair @NotNull [] getPairs() {
+        return PAIRS;
+    }
+
+    @Override
+    public boolean isPairedBracesAllowedBeforeType(@NotNull IElementType lbraceType, @Nullable IElementType contextType) {
+        return true;
+    }
+
+    @Override
+    public int getCodeConstructStart(PsiFile file, int openingBraceOffset) {
+        return openingBraceOffset;
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/SpiceEnterHandler.java
+++ b/src/main/java/com/spicelang/intellij/spice/SpiceEnterHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice;
+
+import com.intellij.application.options.CodeStyle;
+import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegate;
+import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegateAdapter;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.spicelang.intellij.spice.psi.SpiceFile;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Indents the freshly created line(s) after Enter is pressed behind an opening curly brace,
+ * relative to the actual indentation of the brace's line. This complements the formatter, which
+ * otherwise anchors mid-line brace bodies (e.g. lambda bodies) to their canonical indent.
+ */
+public class SpiceEnterHandler extends EnterHandlerDelegateAdapter {
+
+    @Override
+    public Result postProcessEnter(@NotNull PsiFile file, @NotNull Editor editor, @NotNull DataContext dataContext) {
+        if (!(file instanceof SpiceFile)) return Result.Continue;
+
+        Document document = editor.getDocument();
+        int caretOffset = editor.getCaretModel().getOffset();
+        int caretLine = document.getLineNumber(caretOffset);
+        if (caretLine == 0) return Result.Continue;
+
+        // Only act when the previous line ends with an opening brace.
+        String prevText = lineText(document, caretLine - 1);
+        if (!prevText.stripTrailing().endsWith("{")) return Result.Continue;
+
+        String baseIndent = leadingWhitespace(prevText);
+        String newIndent = baseIndent + indentUnit(file);
+
+        // Fix the closing-brace line first (it sits below the caret line, so its offsets stay valid
+        // while we have not yet edited the caret line above it).
+        int lastLine = document.getLineCount() - 1;
+        if (caretLine + 1 <= lastLine) {
+            String nextText = lineText(document, caretLine + 1);
+            if (nextText.stripLeading().startsWith("}")) {
+                replaceLeadingWhitespace(document, caretLine + 1, baseIndent);
+            }
+        }
+
+        // Re-indent the caret line and place the caret at the end of the new indentation.
+        int newCaretOffset = replaceLeadingWhitespace(document, caretLine, newIndent);
+        editor.getCaretModel().moveToOffset(newCaretOffset);
+        return Result.Stop;
+    }
+
+    private static String indentUnit(@NotNull PsiFile file) {
+        CommonCodeStyleSettings.IndentOptions options = CodeStyle.getIndentOptions(file);
+        if (options.USE_TAB_CHARACTER) return "\t";
+        return " ".repeat(Math.max(1, options.INDENT_SIZE));
+    }
+
+    private static String lineText(@NotNull Document document, int line) {
+        int start = document.getLineStartOffset(line);
+        int end = document.getLineEndOffset(line);
+        return document.getText(new TextRange(start, end));
+    }
+
+    private static String leadingWhitespace(@NotNull String text) {
+        int i = 0;
+        while (i < text.length() && (text.charAt(i) == ' ' || text.charAt(i) == '\t')) i++;
+        return text.substring(0, i);
+    }
+
+    /** Replaces the leading whitespace of the given line with {@code indent}; returns the offset right after it. */
+    private static int replaceLeadingWhitespace(@NotNull Document document, int line, @NotNull String indent) {
+        int start = document.getLineStartOffset(line);
+        int whitespaceLength = leadingWhitespace(lineText(document, line)).length();
+        document.replaceString(start, start + whitespaceLength, indent);
+        return start + indent.length();
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/SpiceFormattingModelBuilder.java
+++ b/src/main/java/com/spicelang/intellij/spice/SpiceFormattingModelBuilder.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice;
+
+import com.intellij.formatting.FormattingContext;
+import com.intellij.formatting.FormattingModel;
+import com.intellij.formatting.FormattingModelBuilder;
+import com.intellij.formatting.FormattingModelProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import org.jetbrains.annotations.NotNull;
+
+public class SpiceFormattingModelBuilder implements FormattingModelBuilder {
+
+    @NotNull
+    @Override
+    public FormattingModel createModel(@NotNull FormattingContext context) {
+        PsiElement element = context.getPsiElement();
+        CodeStyleSettings settings = context.getCodeStyleSettings();
+        SpiceBlock rootBlock = new SpiceBlock(element.getNode(), null, null);
+        return FormattingModelProvider.createFormattingModelForPsiFile(
+                element.getContainingFile(), rootBlock, settings);
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -57,6 +57,14 @@
         <lang.foldingBuilder
                 language="Spice"
                 implementationClass="com.spicelang.intellij.spice.SpiceFoldingBuilder"/>
+        <lang.braceMatcher
+                language="Spice"
+                implementationClass="com.spicelang.intellij.spice.SpiceBraceMatcher"/>
+        <lang.formatter
+                language="Spice"
+                implementationClass="com.spicelang.intellij.spice.SpiceFormattingModelBuilder"/>
+        <enterHandlerDelegate
+                implementation="com.spicelang.intellij.spice.SpiceEnterHandler"/>
     </extensions>
 
     <!--<actions></actions>-->


### PR DESCRIPTION
## Summary

Adds three editor-support features to the Spice plugin:

- **Brace matcher** (`SpiceBraceMatcher`) — pairs `{}`, `()` and `[]`, with the curly braces marked *structural*. Enables matching-brace highlighting, "go to matching brace", and unmatched-brace error striping. Angle brackets `<` / `>` are intentionally **not** paired, since they double as comparison/shift operators and would cause constant false matches.
- **Indentation formatting model** (`SpiceFormattingModelBuilder` + `SpiceBlock`) — an indent-only model so that statements/fields/members inside a brace body get one indent level, while the braces themselves stay aligned with the header. `getSpacing` returns `null`, so Reformat normalizes indentation only and never rewrites spaces or collapses lines.
- **Brace-aware Enter handler** (`SpiceEnterHandler`) — indents the new line(s) after Enter behind an opening `{` **relative to the actual indentation of the brace's line**.

## Why the Enter handler

The formatter computes indentation from a construct's *canonical* absolute indent. For a brace body that starts mid-line — e.g. a lambda body `p() test = p() { … }` — it anchors the new line to indent `0` instead of the visible line's indentation, producing:

```
    p() test = p() {
    <cursor>     // wrong: 4 spaces
}                // wrong: 0 spaces
```

`SpiceEnterHandler.postProcessEnter` corrects this after the newline split, purely by rewriting leading whitespace and only when the previous line ends with `{`:

```
    p() test = p() {
        <cursor>     // base indent + one unit
    }                // base indent
```

It honors the code-style indent size / tabs-vs-spaces and leaves all other Enter cases to the default handling.

## Testing

- `./gradlew compileJava` passes.
- Not yet exercised in a live `runIde` session; the Enter handler only ever adjusts leading whitespace guarded on "previous line ends with `{`", so its blast radius is limited to that case.

## Notes / follow-ups

- The Enter-handler guard is textual, so a line literally ending in `{` inside a comment or string would also trigger it; can be tightened with a PSI check if desired.
- A `BasePlatformTestCase` simulating the Enter keystroke would lock this behavior in — happy to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)