### PR TITLE
Add go-to-symbol and go-to-declaration

### DIFF
--- a/src/main/java/com/spicelang/intellij/spice/SpiceChooseByNameContributor.java
+++ b/src/main/java/com/spicelang/intellij/spice/SpiceChooseByNameContributor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice;
+
+import com.intellij.ide.projectView.PresentationData;
+import com.intellij.navigation.ChooseByNameContributor;
+import com.intellij.navigation.ItemPresentation;
+import com.intellij.navigation.NavigationItem;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Feeds Spice declarations into "Go to Symbol" (Ctrl+Alt+Shift+N).
+ */
+public class SpiceChooseByNameContributor implements ChooseByNameContributor {
+
+    @Override
+    public String @NotNull [] getNames(Project project, boolean includeNonProjectItems) {
+        Set<String> names = new HashSet<>();
+        for (SpiceSymbolUtil.Symbol symbol : SpiceSymbolUtil.findSymbols(project)) {
+            names.add(symbol.name);
+        }
+        return names.toArray(new String[0]);
+    }
+
+    @Override
+    public NavigationItem @NotNull [] getItemsByName(String name, String pattern, Project project, boolean includeNonProjectItems) {
+        List<NavigationItem> items = new ArrayList<>();
+        for (SpiceSymbolUtil.Symbol symbol : SpiceSymbolUtil.findSymbols(project, name)) {
+            items.add(new SymbolNavigationItem(symbol));
+        }
+        return items.toArray(new NavigationItem[0]);
+    }
+
+    private static final class SymbolNavigationItem implements NavigationItem {
+
+        private final SpiceSymbolUtil.Symbol symbol;
+
+        private SymbolNavigationItem(SpiceSymbolUtil.Symbol symbol) {
+            this.symbol = symbol;
+        }
+
+        @Override
+        public @NonNull String getName() {
+            return symbol.name;
+        }
+
+        @Override
+        public @NonNull ItemPresentation getPresentation() {
+            PsiElement nameElement = symbol.nameElement;
+            String location = nameElement.getContainingFile() != null ? nameElement.getContainingFile().getName() : null;
+            return new PresentationData(symbol.name, location, SpiceSymbolUtil.iconFor(symbol.kind), null);
+        }
+
+        @Override
+        public void navigate(boolean requestFocus) {
+            VirtualFile virtualFile = virtualFile();
+            if (virtualFile != null) {
+                new OpenFileDescriptor(symbol.nameElement.getProject(), virtualFile,
+                        symbol.nameElement.getTextRange().getStartOffset()).navigate(requestFocus);
+            }
+        }
+
+        @Override
+        public boolean canNavigate() {
+            return virtualFile() != null;
+        }
+
+        @Override
+        public boolean canNavigateToSource() {
+            return canNavigate();
+        }
+
+        @Nullable
+        private VirtualFile virtualFile() {
+            return symbol.nameElement.getContainingFile() != null
+                    ? symbol.nameElement.getContainingFile().getVirtualFile()
+                    : null;
+        }
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/SpiceGotoDeclarationHandler.java
+++ b/src/main/java/com/spicelang/intellij/spice/SpiceGotoDeclarationHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice;
+
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.spicelang.intellij.spice.psi.SpiceDeclStmt;
+import com.spicelang.intellij.spice.psi.SpiceFile;
+import com.spicelang.intellij.spice.psi.SpiceTypes;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Resolves an identifier under the caret (Ctrl+B / Ctrl+click) to its declaration(s).
+ *
+ * <p>This is a name-based resolver: it does not yet model scopes or types, so it returns every
+ * declaration in the project that shares the identifier's simple name, preferring local
+ * declarations of the current file first.
+ */
+public class SpiceGotoDeclarationHandler implements GotoDeclarationHandler {
+
+    @Override
+    public PsiElement @Nullable [] getGotoDeclarationTargets(@Nullable PsiElement sourceElement, int offset, Editor editor) {
+        if (sourceElement == null) return null;
+        ASTNode node = sourceElement.getNode();
+        if (node == null) return null;
+        IElementType type = node.getElementType();
+        if (type != SpiceTypes.IDENTIFIER && type != SpiceTypes.TYPE_IDENTIFIER) return null;
+
+        PsiFile file = sourceElement.getContainingFile();
+        if (!(file instanceof SpiceFile)) return null;
+
+        String name = sourceElement.getText();
+        Project project = sourceElement.getProject();
+
+        Set<PsiElement> targets = new LinkedHashSet<>();
+
+        // 1) Local declarations (parameters and local variables) within the current file.
+        for (SpiceDeclStmt declStmt : PsiTreeUtil.findChildrenOfType(file, SpiceDeclStmt.class)) {
+            ASTNode identifier = declStmt.getNode().findChildByType(SpiceTypes.IDENTIFIER);
+            if (identifier != null && name.equals(identifier.getText())) {
+                targets.add(identifier.getPsi());
+            }
+        }
+
+        // 2) Top-level and member declarations of the current file (index-independent, so this
+        //    works even when the file is not in an indexed content root or the index is cold) ...
+        for (SpiceSymbolUtil.Symbol symbol : SpiceSymbolUtil.findSymbols(file)) {
+            if (name.equals(symbol.name)) targets.add(symbol.nameElement);
+        }
+        // 3) ... and the same declarations across the rest of the project.
+        for (SpiceSymbolUtil.Symbol symbol : SpiceSymbolUtil.findSymbols(project, name)) {
+            targets.add(symbol.nameElement);
+        }
+
+        // Don't resolve an identifier to itself.
+        targets.remove(sourceElement);
+        if (targets.isEmpty()) return null;
+        return targets.toArray(PsiElement.EMPTY_ARRAY);
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/SpiceSymbolUtil.java
+++ b/src/main/java/com/spicelang/intellij/spice/SpiceSymbolUtil.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.FileTypeIndex;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.spicelang.intellij.spice.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Collects the named, top-level (and member) declarations of Spice files. Shared by the
+ * go-to-symbol contributor and the go-to-declaration handler.
+ */
+public final class SpiceSymbolUtil {
+
+    public enum Kind {FUNCTION, PROCEDURE, STRUCT, INTERFACE, ENUM, ENUM_ITEM, FIELD, SIGNATURE, GLOBAL_VAR, ALIAS, GENERIC_TYPE}
+
+    /** A named declaration: its simple name, the identifier leaf to navigate to, and what kind it is. */
+    public static final class Symbol {
+        public final String name;
+        public final PsiElement nameElement;
+        public final Kind kind;
+
+        Symbol(@NotNull String name, @NotNull PsiElement nameElement, @NotNull Kind kind) {
+            this.name = name;
+            this.nameElement = nameElement;
+            this.kind = kind;
+        }
+    }
+
+    private SpiceSymbolUtil() {
+    }
+
+    public static @NotNull List<Symbol> findSymbols(@NotNull Project project) {
+        List<Symbol> result = new ArrayList<>();
+        Collection<VirtualFile> files = FileTypeIndex.getFiles(SpiceFileType.INSTANCE, GlobalSearchScope.allScope(project));
+        for (VirtualFile virtualFile : files) {
+            PsiFile psiFile = PsiManager.getInstance(project).findFile(virtualFile);
+            if (psiFile instanceof SpiceFile) collectSymbols((SpiceFile) psiFile, result);
+        }
+        return result;
+    }
+
+    /** Collects symbols from a single file directly, without relying on the (possibly cold) file index. */
+    public static @NotNull List<Symbol> findSymbols(@NotNull PsiFile file) {
+        List<Symbol> result = new ArrayList<>();
+        if (file instanceof SpiceFile) collectSymbols((SpiceFile) file, result);
+        return result;
+    }
+
+    public static @NotNull List<Symbol> findSymbols(@NotNull Project project, @NotNull String name) {
+        List<Symbol> result = new ArrayList<>();
+        for (Symbol symbol : findSymbols(project)) {
+            if (symbol.name.equals(name)) result.add(symbol);
+        }
+        return result;
+    }
+
+    private static void collectSymbols(@NotNull SpiceFile file, @NotNull List<Symbol> out) {
+        // Each kind is collected independently with a deep search, so a single malformed node
+        // (or an unexpected nesting) cannot prevent the remaining declarations from being found.
+        for (SpiceFunctionDef def : PsiTreeUtil.findChildrenOfType(file, SpiceFunctionDef.class)) {
+            addToken(out, def.getFunctionName(), SpiceTypes.IDENTIFIER, Kind.FUNCTION);
+        }
+        for (SpiceProcedureDef def : PsiTreeUtil.findChildrenOfType(file, SpiceProcedureDef.class)) {
+            addToken(out, def.getFunctionName(), SpiceTypes.IDENTIFIER, Kind.PROCEDURE);
+        }
+        for (SpiceStructDef def : PsiTreeUtil.findChildrenOfType(file, SpiceStructDef.class)) {
+            addToken(out, def, SpiceTypes.TYPE_IDENTIFIER, Kind.STRUCT);
+        }
+        for (SpiceInterfaceDef def : PsiTreeUtil.findChildrenOfType(file, SpiceInterfaceDef.class)) {
+            addToken(out, def, SpiceTypes.TYPE_IDENTIFIER, Kind.INTERFACE);
+        }
+        for (SpiceEnumDef def : PsiTreeUtil.findChildrenOfType(file, SpiceEnumDef.class)) {
+            addToken(out, def, SpiceTypes.TYPE_IDENTIFIER, Kind.ENUM);
+        }
+        for (SpiceGlobalVarDef def : PsiTreeUtil.findChildrenOfType(file, SpiceGlobalVarDef.class)) {
+            addToken(out, def, SpiceTypes.TYPE_IDENTIFIER, Kind.GLOBAL_VAR);
+        }
+        for (SpiceAliasDef def : PsiTreeUtil.findChildrenOfType(file, SpiceAliasDef.class)) {
+            addToken(out, def, SpiceTypes.TYPE_IDENTIFIER, Kind.ALIAS);
+        }
+        for (SpiceGenericTypeDef def : PsiTreeUtil.findChildrenOfType(file, SpiceGenericTypeDef.class)) {
+            addToken(out, def, SpiceTypes.TYPE_IDENTIFIER, Kind.GENERIC_TYPE);
+        }
+        for (SpiceField field : PsiTreeUtil.findChildrenOfType(file, SpiceField.class)) {
+            addToken(out, field, SpiceTypes.IDENTIFIER, Kind.FIELD);
+        }
+        for (SpiceSignature signature : PsiTreeUtil.findChildrenOfType(file, SpiceSignature.class)) {
+            addToken(out, signature, SpiceTypes.IDENTIFIER, Kind.SIGNATURE);
+        }
+        for (SpiceEnumItem item : PsiTreeUtil.findChildrenOfType(file, SpiceEnumItem.class)) {
+            addToken(out, item, SpiceTypes.TYPE_IDENTIFIER, Kind.ENUM_ITEM);
+        }
+    }
+
+    private static void addToken(@NotNull List<Symbol> out, @Nullable PsiElement parent, @NotNull IElementType type, @NotNull Kind kind) {
+        if (parent == null) return;
+        ASTNode node = parent.getNode().findChildByType(type);
+        if (node == null) return;
+        out.add(new Symbol(node.getText(), node.getPsi(), kind));
+    }
+
+    public static @NotNull Icon iconFor(@NotNull Kind kind) {
+        return switch (kind) {
+            case FUNCTION, PROCEDURE -> AllIcons.Nodes.Method;
+            case SIGNATURE -> AllIcons.Nodes.AbstractMethod;
+            case STRUCT, ALIAS, GENERIC_TYPE -> AllIcons.Nodes.Class;
+            case INTERFACE -> AllIcons.Nodes.Interface;
+            case ENUM -> AllIcons.Nodes.Enum;
+            case ENUM_ITEM -> AllIcons.Nodes.Constant;
+            case FIELD -> AllIcons.Nodes.Field;
+            case GLOBAL_VAR -> AllIcons.Nodes.Gvariable;
+        };
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -65,6 +65,10 @@
                 implementationClass="com.spicelang.intellij.spice.SpiceFormattingModelBuilder"/>
         <enterHandlerDelegate
                 implementation="com.spicelang.intellij.spice.SpiceEnterHandler"/>
+        <gotoSymbolContributor
+                implementation="com.spicelang.intellij.spice.SpiceChooseByNameContributor"/>
+        <gotoDeclarationHandler
+                implementation="com.spicelang.intellij.spice.SpiceGotoDeclarationHandler"/>
     </extensions>
 
     <!--<actions></actions>-->


### PR DESCRIPTION
## Summary

Adds symbol navigation to the Spice plugin:

- **Go to Symbol** (Ctrl+Alt+Shift+N) via `SpiceChooseByNameContributor` — lists functions, procedures, structs (+ fields), interfaces (+ signatures), enums (+ items), global vars, aliases and generic types, each with an icon and its containing file.
- **Go to Declaration** (Ctrl+B / Ctrl+click) via `SpiceGotoDeclarationHandler` — resolves the identifier under the caret to its declaration(s).
- **`SpiceSymbolUtil`** — shared collection of named declarations using a deep, per-kind, null-guarded `findChildrenOfType` scan, so a single malformed node can't abort the whole scan.

## Resolution order

`SpiceGotoDeclarationHandler` returns, in order:

1. Local declarations (parameters / locals via `declStmt`) in the current file.
2. Top-level and member declarations of the **current file**, collected directly — index-independent, so it works even when the file isn't in an indexed content root or the index is cold.
3. The same declarations across the rest of the project, via `FileTypeIndex`.

Step 2 is what makes functions/procedures/structs resolve reliably: the earlier version relied solely on the project file index, which returns nothing when the edited file isn't indexed — so only same-file *variables* (resolved directly) worked.

## Limitations

- **Name-based**, not scope/type-aware: an ambiguous name (e.g. a field and a local both called `x`, or a method `bar` on two structs) yields multiple targets and the IDE shows a chooser. Precise resolution needs a scope/type layer — a natural follow-up that would also enable accurate find-usages and rename.
- Operator-overload functions (no simple identifier name) are not contributed.
- No stub index yet; each query re-scans files. Fine for normal projects; a `StringStubIndex` is the scalable upgrade.

## Testing

- `./gradlew compileJava` passes.
- Verified by compilation + code-flow review; not yet exercised in a live `runIde` session. A `BasePlatformTestCase` asserting `GotoDeclarationAction` offsets for a function/struct/variable would lock this in — happy to add as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)