### PR TITLE
Bump version to 1.0.12 and add change notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.0.12]
+- Add structure view outlining functions, types and their members
+- Add code folding for blocks, type bodies and comments
+- Add brace matching for `{}`, `()` and `[]`
+- Add automatic indentation after an opening brace
+- Add Go to Symbol and Go to Declaration support
+
 ## [1.0.11]
 - Support IntelliJ 2026.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginGroup = com.spicelang.intellij-spice
 pluginName = Spice
 pluginRepositoryUrl = https://github.com/spicelang/intellij-spice
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.11
+pluginVersion = 1.0.12
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
 <idea-plugin>
     <id>com.spicelang.intellij-spice</id>
     <name>Spice</name>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
     <vendor url="https://www.chillibits.com" email="support@chillibits.com">ChilliBits</vendor>
     <description>
         <![CDATA[


### PR DESCRIPTION
## Summary

Cuts the **1.0.12** release covering the editor features added this cycle.

- `gradle.properties`: `pluginVersion` `1.0.11` → `1.0.12` (drives the published artifact version and the change-notes lookup).
- `CHANGELOG.md`: new `## [1.0.12]` section.
- `plugin.xml`: `<version>` bumped to keep source in sync (the build patches this field anyway).

## Change notes (1.0.12)

- Add structure view outlining functions, types and their members
- Add code folding for blocks, type bodies and comments
- Add brace matching for `{}`, `()` and `[]`
- Add automatic indentation after an opening brace
- Add Go to Symbol and Go to Declaration support

## Notes

- Versioning follows the repo's established patch-bump convention. If you'd rather signal this larger feature batch as a minor release, this can be `1.1.0` instead — easy to adjust.
- Verified with `patchPluginXml`: the changelog parses and renders into `plugin.xml`'s `<change-notes>` as the five bullets, headed by a `1.0.11...1.0.12` compare link. Project `version` resolves to `1.0.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)