### PR TITLE
Introduce support for forward declarations

### DIFF
--- a/media/test-file.spice
+++ b/media/test-file.spice
@@ -133,6 +133,8 @@ const int SEEK_SET = 0;
 const int SEEK_CUR = 1;
 const int SEEK_END = 2;
 
+forward type File struct;
+
 // spice:Test
 type FilePtr struct {
     byte* ptr

--- a/src/main/gen/com/spicelang/intellij/spice/SpiceLexer.java
+++ b/src/main/gen/com/spicelang/intellij/spice/SpiceLexer.java
@@ -114,18 +114,18 @@ class SpiceLexer implements FlexLexer {
     "\3\0\4\17\1\76\1\77\13\32\1\100\2\32\1\101"+
     "\1\32\1\102\3\32\1\103\1\104\2\32\1\105\17\32"+
     "\1\0\1\56\3\0\1\106\3\32\1\107\1\32\1\110"+
-    "\1\111\1\112\1\113\5\32\1\114\1\115\3\32\1\116"+
+    "\1\111\1\112\1\113\5\32\1\114\1\115\4\32\1\116"+
     "\3\32\1\117\1\120\14\32\1\121\1\122\3\32\1\106"+
     "\1\123\1\124\2\32\1\125\1\32\1\126\4\32\1\127"+
-    "\5\32\1\130\3\32\1\131\11\32\1\132\1\32\1\133"+
-    "\3\32\1\134\2\32\1\135\1\136\2\32\1\137\1\140"+
+    "\6\32\1\130\3\32\1\131\11\32\1\132\1\32\1\133"+
+    "\3\32\1\134\3\32\1\135\1\136\2\32\1\137\1\140"+
     "\1\141\1\142\1\143\1\144\1\145\1\146\1\32\1\147"+
     "\1\150\1\32\1\151\1\152\1\32\1\153\1\32\1\154"+
-    "\2\32\1\155\1\32\1\156\2\32\1\157\1\160\1\32"+
-    "\1\161\1\32\1\162";
+    "\1\155\2\32\1\156\1\32\1\157\2\32\1\160\1\161"+
+    "\1\32\1\162\1\32\1\163";
 
   private static int [] zzUnpackAction() {
-    int [] result = new int[303];
+    int [] result = new int[307];
     int offset = 0;
     offset = zzUnpackAction(ZZ_ACTION_PACKED_0, offset, result);
     return result;
@@ -175,22 +175,23 @@ class SpiceLexer implements FlexLexer {
     "\0\u22cf\0\u2312\0\u2355\0\u2398\0\u2398\0\u23db\0\u241e\0\u2461"+
     "\0\u241e\0\u24a4\0\u24e7\0\u252a\0\u05c2\0\u256d\0\u05c2\0\u05c2"+
     "\0\u05c2\0\u05c2\0\u25b0\0\u25f3\0\u2636\0\u2679\0\u26bc\0\u05c2"+
-    "\0\u05c2\0\u26ff\0\u2742\0\u2785\0\u05c2\0\u27c8\0\u280b\0\u284e"+
-    "\0\u05c2\0\u05c2\0\u2891\0\u28d4\0\u2917\0\u295a\0\u299d\0\u29e0"+
-    "\0\u2a23\0\u2a66\0\u2aa9\0\u2aec\0\u2b2f\0\u2b72\0\u05c2\0\u2bb5"+
-    "\0\u2bf8\0\u2c3b\0\u2c7e\0\103\0\103\0\u05c2\0\u2cc1\0\u2d04"+
-    "\0\u05c2\0\u2d47\0\u05c2\0\u2d8a\0\u2dcd\0\u2e10\0\u2e53\0\u05c2"+
-    "\0\u2e96\0\u2ed9\0\u2f1c\0\u2f5f\0\u2fa2\0\u05c2\0\u2fe5\0\u3028"+
-    "\0\u306b\0\u05c2\0\u30ae\0\u30f1\0\u3134\0\u3177\0\u31ba\0\u31fd"+
-    "\0\u3240\0\u3283\0\u32c6\0\u05c2\0\u3309\0\u05c2\0\u334c\0\u338f"+
-    "\0\u33d2\0\u05c2\0\u3415\0\u3458\0\u05c2\0\u05c2\0\u349b\0\u34de"+
-    "\0\u05c2\0\u05c2\0\u05c2\0\u05c2\0\u05c2\0\u05c2\0\u05c2\0\u05c2"+
-    "\0\u3521\0\u05c2\0\u05c2\0\u3564\0\u05c2\0\u05c2\0\u35a7\0\u05c2"+
-    "\0\u35ea\0\u05c2\0\u362d\0\u3670\0\u05c2\0\u36b3\0\u05c2\0\u36f6"+
-    "\0\u3739\0\u05c2\0\u05c2\0\u377c\0\u05c2\0\u37bf\0\u05c2";
+    "\0\u05c2\0\u26ff\0\u2742\0\u2785\0\u27c8\0\u05c2\0\u280b\0\u284e"+
+    "\0\u2891\0\u05c2\0\u05c2\0\u28d4\0\u2917\0\u295a\0\u299d\0\u29e0"+
+    "\0\u2a23\0\u2a66\0\u2aa9\0\u2aec\0\u2b2f\0\u2b72\0\u2bb5\0\u05c2"+
+    "\0\u2bf8\0\u2c3b\0\u2c7e\0\u2cc1\0\103\0\103\0\u05c2\0\u2d04"+
+    "\0\u2d47\0\u05c2\0\u2d8a\0\u05c2\0\u2dcd\0\u2e10\0\u2e53\0\u2e96"+
+    "\0\u05c2\0\u2ed9\0\u2f1c\0\u2f5f\0\u2fa2\0\u2fe5\0\u3028\0\u05c2"+
+    "\0\u306b\0\u30ae\0\u30f1\0\u05c2\0\u3134\0\u3177\0\u31ba\0\u31fd"+
+    "\0\u3240\0\u3283\0\u32c6\0\u3309\0\u334c\0\u05c2\0\u338f\0\u05c2"+
+    "\0\u33d2\0\u3415\0\u3458\0\u05c2\0\u349b\0\u34de\0\u3521\0\u05c2"+
+    "\0\u05c2\0\u3564\0\u35a7\0\u05c2\0\u05c2\0\u05c2\0\u05c2\0\u05c2"+
+    "\0\u05c2\0\u05c2\0\u05c2\0\u35ea\0\u05c2\0\u05c2\0\u362d\0\u05c2"+
+    "\0\u05c2\0\u3670\0\u05c2\0\u36b3\0\u05c2\0\u05c2\0\u36f6\0\u3739"+
+    "\0\u05c2\0\u377c\0\u05c2\0\u37bf\0\u3802\0\u05c2\0\u05c2\0\u3845"+
+    "\0\u05c2\0\u3888\0\u05c2";
 
   private static int [] zzUnpackRowMap() {
-    int [] result = new int[303];
+    int [] result = new int[307];
     int offset = 0;
     offset = zzUnpackRowMap(ZZ_ROWMAP_PACKED_0, offset, result);
     return result;
@@ -321,108 +322,111 @@ class SpiceLexer implements FlexLexer {
     "\5\36\1\310\22\36\26\0\4\36\6\0\7\36\4\0"+
     "\14\36\1\311\13\36\26\0\4\36\6\0\7\36\4\0"+
     "\13\36\1\312\5\36\1\313\6\36\26\0\4\36\6\0"+
-    "\7\36\4\0\5\36\1\314\22\36\26\0\4\36\6\0"+
-    "\7\36\4\0\17\36\1\315\10\36\26\0\4\36\6\0"+
-    "\7\36\4\0\16\36\1\316\11\36\26\0\4\36\6\0"+
-    "\7\36\4\0\11\36\1\317\16\36\26\0\4\36\6\0"+
-    "\7\36\4\0\5\36\1\320\22\36\26\0\4\36\6\0"+
-    "\7\36\4\0\7\36\1\321\20\36\26\0\4\36\6\0"+
-    "\7\36\4\0\15\36\1\322\12\36\26\0\4\36\6\0"+
-    "\7\36\4\0\20\36\1\323\7\36\26\0\4\36\6\0"+
-    "\7\36\4\0\11\36\1\324\16\36\26\0\4\36\6\0"+
-    "\7\36\4\0\15\36\1\325\12\36\26\0\4\36\6\0"+
-    "\7\36\4\0\13\36\1\326\14\36\26\0\4\36\6\0"+
-    "\7\36\4\0\23\36\1\327\4\36\26\0\4\36\6\0"+
-    "\7\36\4\0\20\36\1\330\7\36\26\0\4\36\6\0"+
-    "\7\36\4\0\15\36\1\331\12\36\26\0\4\36\6\0"+
-    "\7\36\4\0\5\36\1\332\22\36\26\0\4\36\6\0"+
-    "\7\36\4\0\11\36\1\333\11\36\1\334\4\36\26\0"+
-    "\4\36\6\0\7\36\4\0\22\36\1\335\5\36\26\0"+
-    "\4\36\6\0\7\36\4\0\3\36\1\336\24\36\26\0"+
-    "\4\36\6\0\7\36\4\0\5\36\1\337\22\36\26\0"+
-    "\4\36\6\0\7\36\4\0\5\36\1\340\22\36\26\0"+
-    "\4\36\6\0\7\36\4\0\1\36\1\341\7\36\1\342"+
-    "\16\36\26\0\4\36\6\0\7\36\4\0\13\36\1\343"+
-    "\14\36\26\0\4\265\55\0\14\204\1\266\4\204\1\344"+
-    "\61\204\14\267\1\270\102\267\1\270\4\267\1\345\61\267"+
-    "\22\0\4\36\6\0\7\36\4\0\21\36\1\346\6\36"+
-    "\26\0\4\36\6\0\7\36\4\0\15\36\1\347\12\36"+
-    "\26\0\4\36\6\0\7\36\4\0\20\36\1\350\7\36"+
-    "\26\0\4\36\6\0\7\36\4\0\12\36\1\351\15\36"+
-    "\26\0\4\36\6\0\7\36\4\0\16\36\1\352\11\36"+
-    "\26\0\4\36\6\0\7\36\4\0\22\36\1\353\5\36"+
-    "\26\0\4\36\6\0\7\36\4\0\11\36\1\354\16\36"+
-    "\26\0\4\36\6\0\7\36\4\0\23\36\1\355\4\36"+
-    "\26\0\4\36\6\0\7\36\4\0\13\36\1\356\14\36"+
-    "\26\0\4\36\6\0\7\36\4\0\22\36\1\357\5\36"+
-    "\26\0\4\36\6\0\7\36\4\0\5\36\1\360\22\36"+
-    "\26\0\4\36\6\0\7\36\4\0\1\36\1\361\26\36"+
-    "\26\0\4\36\6\0\7\36\4\0\20\36\1\362\7\36"+
-    "\26\0\4\36\6\0\7\36\4\0\15\36\1\363\12\36"+
-    "\26\0\4\36\6\0\7\36\4\0\20\36\1\364\7\36"+
-    "\26\0\4\36\6\0\7\36\4\0\1\36\1\365\26\36"+
-    "\26\0\4\36\6\0\7\36\4\0\3\36\1\366\24\36"+
-    "\26\0\4\36\6\0\7\36\4\0\22\36\1\367\5\36"+
-    "\26\0\4\36\6\0\7\36\4\0\11\36\1\370\16\36"+
-    "\26\0\4\36\6\0\7\36\4\0\20\36\1\371\7\36"+
-    "\26\0\4\36\6\0\7\36\4\0\22\36\1\372\5\36"+
-    "\26\0\4\36\6\0\7\36\4\0\5\36\1\373\22\36"+
-    "\26\0\4\36\6\0\7\36\4\0\16\36\1\374\11\36"+
-    "\26\0\4\36\6\0\7\36\4\0\15\36\1\375\12\36"+
-    "\26\0\4\36\6\0\7\36\4\0\3\36\1\376\24\36"+
-    "\26\0\4\36\6\0\7\36\4\0\3\36\1\377\24\36"+
-    "\26\0\4\36\6\0\7\36\4\0\1\36\1\u0100\26\36"+
-    "\26\0\4\36\6\0\7\36\4\0\11\36\1\u0101\16\36"+
-    "\26\0\4\36\6\0\7\36\4\0\6\36\1\u0102\21\36"+
-    "\26\0\4\36\6\0\7\36\4\0\7\36\1\u0103\20\36"+
-    "\26\0\4\36\6\0\7\36\4\0\5\36\1\u0104\22\36"+
-    "\26\0\4\36\6\0\7\36\4\0\16\36\1\u0105\11\36"+
-    "\26\0\4\36\6\0\7\36\4\0\22\36\1\u0106\5\36"+
-    "\26\0\4\36\6\0\7\36\4\0\21\36\1\u0107\6\36"+
-    "\26\0\4\36\6\0\7\36\4\0\15\36\1\u0108\12\36"+
-    "\26\0\4\36\6\0\7\36\4\0\13\36\1\u0109\14\36"+
-    "\26\0\4\36\6\0\7\36\4\0\5\36\1\u010a\22\36"+
-    "\26\0\4\36\6\0\7\36\4\0\10\36\1\u010b\17\36"+
-    "\26\0\4\36\6\0\7\36\4\0\3\36\1\u010c\24\36"+
-    "\26\0\4\36\6\0\7\36\4\0\22\36\1\u010d\5\36"+
-    "\26\0\4\36\6\0\7\36\4\0\5\36\1\u010e\22\36"+
-    "\26\0\4\36\6\0\7\36\4\0\6\36\1\u010f\21\36"+
-    "\26\0\4\36\6\0\7\36\4\0\22\36\1\u0110\5\36"+
-    "\26\0\4\36\6\0\7\36\4\0\6\36\1\u0111\21\36"+
-    "\26\0\4\36\6\0\7\36\4\0\3\36\1\u0112\24\36"+
-    "\26\0\4\36\6\0\7\36\4\0\15\36\1\u0113\12\36"+
-    "\26\0\4\36\6\0\7\36\4\0\4\36\1\u0114\23\36"+
-    "\26\0\4\36\6\0\7\36\4\0\6\36\1\u0115\21\36"+
-    "\26\0\4\36\6\0\7\36\4\0\7\36\1\u0116\20\36"+
-    "\26\0\4\36\6\0\7\36\4\0\22\36\1\u0117\5\36"+
-    "\26\0\4\36\6\0\7\36\4\0\10\36\1\u0118\17\36"+
-    "\26\0\4\36\6\0\7\36\4\0\13\36\1\u0119\14\36"+
-    "\26\0\4\36\6\0\7\36\4\0\4\36\1\u011a\23\36"+
-    "\26\0\4\36\6\0\7\36\4\0\5\36\1\u011b\22\36"+
-    "\26\0\4\36\6\0\7\36\4\0\15\36\1\u011c\12\36"+
-    "\26\0\4\36\6\0\7\36\4\0\6\36\1\u011d\21\36"+
-    "\26\0\4\36\6\0\7\36\4\0\5\36\1\u011e\22\36"+
-    "\26\0\4\36\6\0\7\36\4\0\23\36\1\u011f\4\36"+
-    "\26\0\4\36\6\0\7\36\4\0\22\36\1\u0120\5\36"+
-    "\26\0\4\36\6\0\7\36\4\0\20\36\1\u0121\7\36"+
-    "\26\0\4\36\6\0\7\36\4\0\10\36\1\u0122\17\36"+
-    "\26\0\4\36\6\0\7\36\4\0\1\36\1\u0123\26\36"+
-    "\26\0\4\36\6\0\7\36\4\0\16\36\1\u0124\11\36"+
-    "\26\0\4\36\6\0\7\36\4\0\13\36\1\u0125\14\36"+
-    "\26\0\4\36\6\0\7\36\4\0\5\36\1\u0126\22\36"+
-    "\26\0\4\36\6\0\7\36\4\0\5\36\1\u0127\22\36"+
-    "\26\0\4\36\6\0\7\36\4\0\16\36\1\u0128\11\36"+
-    "\26\0\4\36\6\0\7\36\4\0\3\36\1\u0129\24\36"+
-    "\26\0\4\36\6\0\7\36\4\0\20\36\1\u012a\7\36"+
-    "\26\0\4\36\6\0\7\36\4\0\4\36\1\u012b\23\36"+
-    "\26\0\4\36\6\0\7\36\4\0\23\36\1\u012c\4\36"+
-    "\26\0\4\36\6\0\7\36\4\0\5\36\1\u012d\22\36"+
-    "\26\0\4\36\6\0\7\36\4\0\7\36\1\u012e\20\36"+
-    "\26\0\4\36\6\0\7\36\4\0\10\36\1\u012f\17\36"+
-    "\4\0";
+    "\7\36\4\0\5\36\1\314\16\36\1\315\3\36\26\0"+
+    "\4\36\6\0\7\36\4\0\17\36\1\316\10\36\26\0"+
+    "\4\36\6\0\7\36\4\0\16\36\1\317\11\36\26\0"+
+    "\4\36\6\0\7\36\4\0\11\36\1\320\16\36\26\0"+
+    "\4\36\6\0\7\36\4\0\5\36\1\321\22\36\26\0"+
+    "\4\36\6\0\7\36\4\0\7\36\1\322\20\36\26\0"+
+    "\4\36\6\0\7\36\4\0\15\36\1\323\12\36\26\0"+
+    "\4\36\6\0\7\36\4\0\20\36\1\324\7\36\26\0"+
+    "\4\36\6\0\7\36\4\0\11\36\1\325\16\36\26\0"+
+    "\4\36\6\0\7\36\4\0\15\36\1\326\12\36\26\0"+
+    "\4\36\6\0\7\36\4\0\13\36\1\327\14\36\26\0"+
+    "\4\36\6\0\7\36\4\0\23\36\1\330\4\36\26\0"+
+    "\4\36\6\0\7\36\4\0\20\36\1\331\7\36\26\0"+
+    "\4\36\6\0\7\36\4\0\15\36\1\332\12\36\26\0"+
+    "\4\36\6\0\7\36\4\0\5\36\1\333\22\36\26\0"+
+    "\4\36\6\0\7\36\4\0\11\36\1\334\11\36\1\335"+
+    "\4\36\26\0\4\36\6\0\7\36\4\0\22\36\1\336"+
+    "\5\36\26\0\4\36\6\0\7\36\4\0\3\36\1\337"+
+    "\24\36\26\0\4\36\6\0\7\36\4\0\5\36\1\340"+
+    "\22\36\26\0\4\36\6\0\7\36\4\0\5\36\1\341"+
+    "\22\36\26\0\4\36\6\0\7\36\4\0\1\36\1\342"+
+    "\7\36\1\343\16\36\26\0\4\36\6\0\7\36\4\0"+
+    "\13\36\1\344\14\36\26\0\4\265\55\0\14\204\1\266"+
+    "\4\204\1\345\61\204\14\267\1\270\102\267\1\270\4\267"+
+    "\1\346\61\267\22\0\4\36\6\0\7\36\4\0\21\36"+
+    "\1\347\6\36\26\0\4\36\6\0\7\36\4\0\15\36"+
+    "\1\350\12\36\26\0\4\36\6\0\7\36\4\0\20\36"+
+    "\1\351\7\36\26\0\4\36\6\0\7\36\4\0\12\36"+
+    "\1\352\15\36\26\0\4\36\6\0\7\36\4\0\16\36"+
+    "\1\353\11\36\26\0\4\36\6\0\7\36\4\0\22\36"+
+    "\1\354\5\36\26\0\4\36\6\0\7\36\4\0\11\36"+
+    "\1\355\16\36\26\0\4\36\6\0\7\36\4\0\23\36"+
+    "\1\356\4\36\26\0\4\36\6\0\7\36\4\0\13\36"+
+    "\1\357\14\36\26\0\4\36\6\0\7\36\4\0\22\36"+
+    "\1\360\5\36\26\0\4\36\6\0\7\36\4\0\5\36"+
+    "\1\361\22\36\26\0\4\36\6\0\7\36\4\0\1\36"+
+    "\1\362\26\36\26\0\4\36\6\0\7\36\4\0\1\36"+
+    "\1\363\26\36\26\0\4\36\6\0\7\36\4\0\20\36"+
+    "\1\364\7\36\26\0\4\36\6\0\7\36\4\0\15\36"+
+    "\1\365\12\36\26\0\4\36\6\0\7\36\4\0\20\36"+
+    "\1\366\7\36\26\0\4\36\6\0\7\36\4\0\1\36"+
+    "\1\367\26\36\26\0\4\36\6\0\7\36\4\0\3\36"+
+    "\1\370\24\36\26\0\4\36\6\0\7\36\4\0\22\36"+
+    "\1\371\5\36\26\0\4\36\6\0\7\36\4\0\11\36"+
+    "\1\372\16\36\26\0\4\36\6\0\7\36\4\0\20\36"+
+    "\1\373\7\36\26\0\4\36\6\0\7\36\4\0\22\36"+
+    "\1\374\5\36\26\0\4\36\6\0\7\36\4\0\5\36"+
+    "\1\375\22\36\26\0\4\36\6\0\7\36\4\0\16\36"+
+    "\1\376\11\36\26\0\4\36\6\0\7\36\4\0\15\36"+
+    "\1\377\12\36\26\0\4\36\6\0\7\36\4\0\3\36"+
+    "\1\u0100\24\36\26\0\4\36\6\0\7\36\4\0\3\36"+
+    "\1\u0101\24\36\26\0\4\36\6\0\7\36\4\0\1\36"+
+    "\1\u0102\26\36\26\0\4\36\6\0\7\36\4\0\11\36"+
+    "\1\u0103\16\36\26\0\4\36\6\0\7\36\4\0\6\36"+
+    "\1\u0104\21\36\26\0\4\36\6\0\7\36\4\0\7\36"+
+    "\1\u0105\20\36\26\0\4\36\6\0\7\36\4\0\5\36"+
+    "\1\u0106\22\36\26\0\4\36\6\0\7\36\4\0\16\36"+
+    "\1\u0107\11\36\26\0\4\36\6\0\7\36\4\0\22\36"+
+    "\1\u0108\5\36\26\0\4\36\6\0\7\36\4\0\21\36"+
+    "\1\u0109\6\36\26\0\4\36\6\0\7\36\4\0\15\36"+
+    "\1\u010a\12\36\26\0\4\36\6\0\7\36\4\0\13\36"+
+    "\1\u010b\14\36\26\0\4\36\6\0\7\36\4\0\5\36"+
+    "\1\u010c\22\36\26\0\4\36\6\0\7\36\4\0\10\36"+
+    "\1\u010d\17\36\26\0\4\36\6\0\7\36\4\0\3\36"+
+    "\1\u010e\24\36\26\0\4\36\6\0\7\36\4\0\20\36"+
+    "\1\u010f\7\36\26\0\4\36\6\0\7\36\4\0\22\36"+
+    "\1\u0110\5\36\26\0\4\36\6\0\7\36\4\0\5\36"+
+    "\1\u0111\22\36\26\0\4\36\6\0\7\36\4\0\6\36"+
+    "\1\u0112\21\36\26\0\4\36\6\0\7\36\4\0\22\36"+
+    "\1\u0113\5\36\26\0\4\36\6\0\7\36\4\0\6\36"+
+    "\1\u0114\21\36\26\0\4\36\6\0\7\36\4\0\3\36"+
+    "\1\u0115\24\36\26\0\4\36\6\0\7\36\4\0\15\36"+
+    "\1\u0116\12\36\26\0\4\36\6\0\7\36\4\0\4\36"+
+    "\1\u0117\23\36\26\0\4\36\6\0\7\36\4\0\6\36"+
+    "\1\u0118\21\36\26\0\4\36\6\0\7\36\4\0\7\36"+
+    "\1\u0119\20\36\26\0\4\36\6\0\7\36\4\0\22\36"+
+    "\1\u011a\5\36\26\0\4\36\6\0\7\36\4\0\10\36"+
+    "\1\u011b\17\36\26\0\4\36\6\0\7\36\4\0\13\36"+
+    "\1\u011c\14\36\26\0\4\36\6\0\7\36\4\0\4\36"+
+    "\1\u011d\23\36\26\0\4\36\6\0\7\36\4\0\5\36"+
+    "\1\u011e\22\36\26\0\4\36\6\0\7\36\4\0\15\36"+
+    "\1\u011f\12\36\26\0\4\36\6\0\7\36\4\0\6\36"+
+    "\1\u0120\21\36\26\0\4\36\6\0\7\36\4\0\5\36"+
+    "\1\u0121\22\36\26\0\4\36\6\0\7\36\4\0\23\36"+
+    "\1\u0122\4\36\26\0\4\36\6\0\7\36\4\0\22\36"+
+    "\1\u0123\5\36\26\0\4\36\6\0\7\36\4\0\20\36"+
+    "\1\u0124\7\36\26\0\4\36\6\0\7\36\4\0\10\36"+
+    "\1\u0125\17\36\26\0\4\36\6\0\7\36\4\0\4\36"+
+    "\1\u0126\23\36\26\0\4\36\6\0\7\36\4\0\1\36"+
+    "\1\u0127\26\36\26\0\4\36\6\0\7\36\4\0\16\36"+
+    "\1\u0128\11\36\26\0\4\36\6\0\7\36\4\0\13\36"+
+    "\1\u0129\14\36\26\0\4\36\6\0\7\36\4\0\5\36"+
+    "\1\u012a\22\36\26\0\4\36\6\0\7\36\4\0\5\36"+
+    "\1\u012b\22\36\26\0\4\36\6\0\7\36\4\0\16\36"+
+    "\1\u012c\11\36\26\0\4\36\6\0\7\36\4\0\3\36"+
+    "\1\u012d\24\36\26\0\4\36\6\0\7\36\4\0\20\36"+
+    "\1\u012e\7\36\26\0\4\36\6\0\7\36\4\0\4\36"+
+    "\1\u012f\23\36\26\0\4\36\6\0\7\36\4\0\23\36"+
+    "\1\u0130\4\36\26\0\4\36\6\0\7\36\4\0\5\36"+
+    "\1\u0131\22\36\26\0\4\36\6\0\7\36\4\0\7\36"+
+    "\1\u0132\20\36\26\0\4\36\6\0\7\36\4\0\10\36"+
+    "\1\u0133\17\36\4\0";
 
   private static int [] zzUnpacktrans() {
-    int [] result = new int[14338];
+    int [] result = new int[14539];
     int offset = 0;
     offset = zzUnpacktrans(ZZ_TRANS_PACKED_0, offset, result);
     return result;
@@ -465,11 +469,11 @@ class SpiceLexer implements FlexLexer {
     "\1\0\1\11\1\0\4\11\1\0\1\11\1\0\6\11"+
     "\1\0\1\1\1\0\1\1\1\11\5\0\2\11\1\1"+
     "\1\11\1\0\3\11\1\0\1\11\46\1\3\11\3\0"+
-    "\4\1\2\11\50\1\1\0\1\1\3\0\53\1\2\11"+
-    "\112\1";
+    "\4\1\2\11\50\1\1\0\1\1\3\0\54\1\2\11"+
+    "\115\1";
 
   private static int [] zzUnpackAttribute() {
-    int [] result = new int[303];
+    int [] result = new int[307];
     int offset = 0;
     offset = zzUnpackAttribute(ZZ_ATTRIBUTE_PACKED_0, offset, result);
     return result;
@@ -795,572 +799,577 @@ class SpiceLexer implements FlexLexer {
             { return TokenType.BAD_CHARACTER;
             }
           // fall through
-          case 115: break;
+          case 116: break;
           case 2:
             { return TokenType.WHITE_SPACE;
             }
           // fall through
-          case 116: break;
+          case 117: break;
           case 3:
             { return SpiceTypes.NOT;
             }
           // fall through
-          case 117: break;
+          case 118: break;
           case 4:
             { return SpiceTypes.TOPLEVEL_ATTR_PREAMBLE;
             }
           // fall through
-          case 118: break;
+          case 119: break;
           case 5:
             { return SpiceTypes.REM;
             }
           // fall through
-          case 119: break;
+          case 120: break;
           case 6:
             { return SpiceTypes.BITWISE_AND;
             }
           // fall through
-          case 120: break;
+          case 121: break;
           case 7:
             { return SpiceTypes.LPAREN;
             }
           // fall through
-          case 121: break;
+          case 122: break;
           case 8:
             { return SpiceTypes.RPAREN;
             }
           // fall through
-          case 122: break;
+          case 123: break;
           case 9:
             { return SpiceTypes.MUL;
             }
           // fall through
-          case 123: break;
+          case 124: break;
           case 10:
             { return SpiceTypes.PLUS;
             }
           // fall through
-          case 124: break;
+          case 125: break;
           case 11:
             { return SpiceTypes.COMMA;
             }
           // fall through
-          case 125: break;
+          case 126: break;
           case 12:
             { return SpiceTypes.MINUS;
             }
           // fall through
-          case 126: break;
+          case 127: break;
           case 13:
             { return SpiceTypes.DOT;
             }
           // fall through
-          case 127: break;
+          case 128: break;
           case 14:
             { return SpiceTypes.DIV;
             }
           // fall through
-          case 128: break;
+          case 129: break;
           case 15:
             { return SpiceTypes.INT_LIT;
             }
           // fall through
-          case 129: break;
+          case 130: break;
           case 16:
             { return SpiceTypes.COLON;
             }
           // fall through
-          case 130: break;
+          case 131: break;
           case 17:
             { return SpiceTypes.SEMICOLON;
             }
           // fall through
-          case 131: break;
+          case 132: break;
           case 18:
             { return SpiceTypes.LESS;
             }
           // fall through
-          case 132: break;
+          case 133: break;
           case 19:
             { return SpiceTypes.ASSIGN;
             }
           // fall through
-          case 133: break;
+          case 134: break;
           case 20:
             { return SpiceTypes.GREATER;
             }
           // fall through
-          case 134: break;
+          case 135: break;
           case 21:
             { return SpiceTypes.QUESTION_MARK;
             }
           // fall through
-          case 135: break;
+          case 136: break;
           case 22:
             { return SpiceTypes.TYPE_IDENTIFIER;
             }
           // fall through
-          case 136: break;
+          case 137: break;
           case 23:
             { return SpiceTypes.LBRACKET;
             }
           // fall through
-          case 137: break;
+          case 138: break;
           case 24:
             { return SpiceTypes.RBRACKET;
             }
           // fall through
-          case 138: break;
+          case 139: break;
           case 25:
             { return SpiceTypes.BITWISE_XOR;
             }
           // fall through
-          case 139: break;
+          case 140: break;
           case 26:
             { return SpiceTypes.IDENTIFIER;
             }
           // fall through
-          case 140: break;
+          case 141: break;
           case 27:
             { return SpiceTypes.F;
             }
           // fall through
-          case 141: break;
+          case 142: break;
           case 28:
             { return SpiceTypes.P;
             }
           // fall through
-          case 142: break;
+          case 143: break;
           case 29:
             { return SpiceTypes.LBRACE;
             }
           // fall through
-          case 143: break;
+          case 144: break;
           case 30:
             { return SpiceTypes.BITWISE_OR;
             }
           // fall through
-          case 144: break;
+          case 145: break;
           case 31:
             { return SpiceTypes.RBRACE;
             }
           // fall through
-          case 145: break;
+          case 146: break;
           case 32:
             { return SpiceTypes.BITWISE_NOT;
             }
           // fall through
-          case 146: break;
+          case 147: break;
           case 33:
             { return SpiceTypes.NOT_EQUAL;
             }
           // fall through
-          case 147: break;
+          case 148: break;
           case 34:
             { return SpiceTypes.STRING_LIT;
             }
           // fall through
-          case 148: break;
+          case 149: break;
           case 35:
             { return SpiceTypes.MOD_ATTR_PREAMBLE;
             }
           // fall through
-          case 149: break;
+          case 150: break;
           case 36:
             { return SpiceTypes.REM_EQUAL;
             }
           // fall through
-          case 150: break;
+          case 151: break;
           case 37:
             { return SpiceTypes.LOGICAL_AND;
             }
           // fall through
-          case 151: break;
+          case 152: break;
           case 38:
             { return SpiceTypes.AND_EQUAL;
             }
           // fall through
-          case 152: break;
+          case 153: break;
           case 39:
             { return SpiceTypes.CHAR_LIT;
             }
           // fall through
-          case 153: break;
+          case 154: break;
           case 40:
             { return SpiceTypes.MUL_EQUAL;
             }
           // fall through
-          case 154: break;
+          case 155: break;
           case 41:
             { return SpiceTypes.PLUS_PLUS;
             }
           // fall through
-          case 155: break;
+          case 156: break;
           case 42:
             { return SpiceTypes.PLUS_EQUAL;
             }
           // fall through
-          case 156: break;
+          case 157: break;
           case 43:
             { return SpiceTypes.MINUS_MINUS;
             }
           // fall through
-          case 157: break;
+          case 158: break;
           case 44:
             { return SpiceTypes.MINUS_EQUAL;
             }
           // fall through
-          case 158: break;
+          case 159: break;
           case 45:
             { return SpiceTypes.ARROW;
             }
           // fall through
-          case 159: break;
+          case 160: break;
           case 46:
             { return SpiceTypes.DOUBLE_LIT;
             }
           // fall through
-          case 160: break;
+          case 161: break;
           case 47:
             { return SpiceTypes.LINE_COMMENT;
             }
           // fall through
-          case 161: break;
+          case 162: break;
           case 48:
             { return SpiceTypes.DIV_EQUAL;
             }
           // fall through
-          case 162: break;
+          case 163: break;
           case 49:
             { return SpiceTypes.LONG_LIT;
             }
           // fall through
-          case 163: break;
+          case 164: break;
           case 50:
             { return SpiceTypes.SHORT_LIT;
             }
           // fall through
-          case 164: break;
+          case 165: break;
           case 51:
             { return SpiceTypes.SCOPE_ACCESS;
             }
           // fall through
-          case 165: break;
+          case 166: break;
           case 52:
             { return SpiceTypes.LESS_EQUAL;
             }
           // fall through
-          case 166: break;
+          case 167: break;
           case 53:
             { return SpiceTypes.EQUAL;
             }
           // fall through
-          case 167: break;
+          case 168: break;
           case 54:
             { return SpiceTypes.GREATER_EQUAL;
             }
           // fall through
-          case 168: break;
+          case 169: break;
           case 55:
             { return SpiceTypes.XOR_EQUAL;
             }
           // fall through
-          case 169: break;
+          case 170: break;
           case 56:
             { return SpiceTypes.AS;
             }
           // fall through
-          case 170: break;
+          case 171: break;
           case 57:
             { return SpiceTypes.DO;
             }
           // fall through
-          case 171: break;
+          case 172: break;
           case 58:
             { return SpiceTypes.IF;
             }
           // fall through
-          case 172: break;
+          case 173: break;
           case 59:
             { return SpiceTypes.OR_EQUAL;
             }
           // fall through
-          case 173: break;
+          case 174: break;
           case 60:
             { return SpiceTypes.LOGICAL_OR;
             }
           // fall through
-          case 174: break;
+          case 175: break;
           case 61:
             { return SpiceTypes.ELLIPSIS;
             }
           // fall through
-          case 175: break;
+          case 176: break;
           case 62:
             { return SpiceTypes.SHL_EQUAL;
             }
           // fall through
-          case 176: break;
+          case 177: break;
           case 63:
             { return SpiceTypes.SHR_EQUAL;
             }
           // fall through
-          case 177: break;
+          case 178: break;
           case 64:
             { return SpiceTypes.TYPE_DYN;
             }
           // fall through
-          case 178: break;
+          case 179: break;
           case 65:
             { return SpiceTypes.EXT;
             }
           // fall through
-          case 179: break;
+          case 180: break;
           case 66:
             { return SpiceTypes.FOR;
             }
           // fall through
-          case 180: break;
+          case 181: break;
           case 67:
             { return SpiceTypes.TYPE_INT;
             }
           // fall through
-          case 181: break;
+          case 182: break;
           case 68:
             { return SpiceTypes.LEN;
             }
           // fall through
-          case 182: break;
+          case 183: break;
           case 69:
             { return SpiceTypes.NIL;
             }
           // fall through
-          case 183: break;
+          case 184: break;
           case 70:
             { return SpiceTypes.BLOCK_COMMENT;
             }
           // fall through
-          case 184: break;
+          case 185: break;
           case 71:
             { return SpiceTypes.TYPE_BOOL;
             }
           // fall through
-          case 185: break;
+          case 186: break;
           case 72:
             { return SpiceTypes.TYPE_BYTE;
             }
           // fall through
-          case 186: break;
+          case 187: break;
           case 73:
             { return SpiceTypes.CASE;
             }
           // fall through
-          case 187: break;
+          case 188: break;
           case 74:
             { return SpiceTypes.CAST;
             }
           // fall through
-          case 188: break;
+          case 189: break;
           case 75:
             { return SpiceTypes.TYPE_CHAR;
             }
           // fall through
-          case 189: break;
+          case 190: break;
           case 76:
             { return SpiceTypes.ELSE;
             }
           // fall through
-          case 190: break;
+          case 191: break;
           case 77:
             { return SpiceTypes.ENUM;
             }
           // fall through
-          case 191: break;
+          case 192: break;
           case 78:
             { return SpiceTypes.HEAP;
             }
           // fall through
-          case 192: break;
+          case 193: break;
           case 79:
             { return SpiceTypes.TYPE_LONG;
             }
           // fall through
-          case 193: break;
+          case 194: break;
           case 80:
             { return SpiceTypes.MAIN;
             }
           // fall through
-          case 194: break;
+          case 195: break;
           case 81:
             { return SpiceTypes.TRUE;
             }
           // fall through
-          case 195: break;
+          case 196: break;
           case 82:
             { return SpiceTypes.TYPE;
             }
           // fall through
-          case 196: break;
+          case 197: break;
           case 83:
             { return SpiceTypes.DOC_COMMENT;
             }
           // fall through
-          case 197: break;
+          case 198: break;
           case 84:
             { return SpiceTypes.ALIAS;
             }
           // fall through
-          case 198: break;
+          case 199: break;
           case 85:
             { return SpiceTypes.BREAK;
             }
           // fall through
-          case 199: break;
+          case 200: break;
           case 86:
             { return SpiceTypes.CONST;
             }
           // fall through
-          case 200: break;
+          case 201: break;
           case 87:
             { return SpiceTypes.FALSE;
             }
           // fall through
-          case 201: break;
+          case 202: break;
           case 88:
             { return SpiceTypes.PANIC;
             }
           // fall through
-          case 202: break;
+          case 203: break;
           case 89:
             { return SpiceTypes.TYPE_SHORT;
             }
           // fall through
-          case 203: break;
+          case 204: break;
           case 90:
             { return SpiceTypes.WHILE;
             }
           // fall through
-          case 204: break;
+          case 205: break;
           case 91:
             { return SpiceTypes.ASSERT;
             }
           // fall through
-          case 205: break;
+          case 206: break;
           case 92:
             { return SpiceTypes.TYPE_DOUBLE;
             }
           // fall through
-          case 206: break;
+          case 207: break;
           case 93:
             { return SpiceTypes.IMPORT;
             }
           // fall through
-          case 207: break;
+          case 208: break;
           case 94:
             { return SpiceTypes.INLINE;
             }
           // fall through
-          case 208: break;
+          case 209: break;
           case 95:
             { return SpiceTypes.PRINTF;
             }
           // fall through
-          case 209: break;
+          case 210: break;
           case 96:
             { return SpiceTypes.PUBLIC;
             }
           // fall through
-          case 210: break;
+          case 211: break;
           case 97:
             { return SpiceTypes.RETURN;
             }
           // fall through
-          case 211: break;
+          case 212: break;
           case 98:
             { return SpiceTypes.SIGNED;
             }
           // fall through
-          case 212: break;
+          case 213: break;
           case 99:
             { return SpiceTypes.SIZEOF;
             }
           // fall through
-          case 213: break;
+          case 214: break;
           case 100:
             { return SpiceTypes.TYPE_STRING;
             }
           // fall through
-          case 214: break;
+          case 215: break;
           case 101:
             { return SpiceTypes.STRUCT;
             }
           // fall through
-          case 215: break;
+          case 216: break;
           case 102:
             { return SpiceTypes.SWITCH;
             }
           // fall through
-          case 216: break;
+          case 217: break;
           case 103:
             { return SpiceTypes.TYPEID;
             }
           // fall through
-          case 217: break;
+          case 218: break;
           case 104:
             { return SpiceTypes.UNSAFE;
             }
           // fall through
-          case 218: break;
+          case 219: break;
           case 105:
             { return SpiceTypes.ALIGNOF;
             }
           // fall through
-          case 219: break;
+          case 220: break;
           case 106:
             { return SpiceTypes.COMPOSE;
             }
           // fall through
-          case 220: break;
+          case 221: break;
           case 107:
             { return SpiceTypes.DEFAULT;
             }
           // fall through
-          case 221: break;
+          case 222: break;
           case 108:
             { return SpiceTypes.FOREACH;
             }
           // fall through
-          case 222: break;
-          case 109:
-            { return SpiceTypes.SYSCALL;
-            }
-          // fall through
           case 223: break;
-          case 110:
-            { return SpiceTypes.CONTINUE;
+          case 109:
+            { return SpiceTypes.FORWARD;
             }
           // fall through
           case 224: break;
-          case 111:
-            { return SpiceTypes.OPERATOR;
+          case 110:
+            { return SpiceTypes.SYSCALL;
             }
           // fall through
           case 225: break;
-          case 112:
-            { return SpiceTypes.UNSIGNED;
+          case 111:
+            { return SpiceTypes.CONTINUE;
             }
           // fall through
           case 226: break;
-          case 113:
-            { return SpiceTypes.INTERFACE;
+          case 112:
+            { return SpiceTypes.OPERATOR;
             }
           // fall through
           case 227: break;
-          case 114:
-            { return SpiceTypes.FALLTHROUGH;
+          case 113:
+            { return SpiceTypes.UNSIGNED;
             }
           // fall through
           case 228: break;
+          case 114:
+            { return SpiceTypes.INTERFACE;
+            }
+          // fall through
+          case 229: break;
+          case 115:
+            { return SpiceTypes.FALLTHROUGH;
+            }
+          // fall through
+          case 230: break;
           default:
             zzScanError(ZZ_NO_MATCH);
           }

--- a/src/main/gen/com/spicelang/intellij/spice/SpiceParser.java
+++ b/src/main/gen/com/spicelang/intellij/spice/SpiceParser.java
@@ -79,7 +79,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // specifierLst? TYPE TYPE_IDENTIFIER ALIAS dataType SEMICOLON
+  // qualifierLst? TYPE TYPE_IDENTIFIER ALIAS dataType SEMICOLON
   public static boolean aliasDef(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "aliasDef")) return false;
     boolean r;
@@ -92,10 +92,10 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // specifierLst?
+  // qualifierLst?
   private static boolean aliasDef_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "aliasDef_0")) return false;
-    specifierLst(b, l + 1);
+    qualifierLst(b, l + 1);
     return true;
   }
 
@@ -811,7 +811,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // specifierLst? baseDataType (MUL | BITWISE_AND | LBRACKET (INT_LIT | TYPE_IDENTIFIER)? RBRACKET)*
+  // qualifierLst? baseDataType (MUL | BITWISE_AND | LBRACKET (INT_LIT | TYPE_IDENTIFIER)? RBRACKET)*
   public static boolean dataType(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "dataType")) return false;
     boolean r;
@@ -823,10 +823,10 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // specifierLst?
+  // qualifierLst?
   private static boolean dataType_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "dataType_0")) return false;
-    specifierLst(b, l + 1);
+    qualifierLst(b, l + 1);
     return true;
   }
 
@@ -989,7 +989,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // specifierLst? TYPE TYPE_IDENTIFIER ENUM LBRACE enumItemLst RBRACE
+  // qualifierLst? TYPE TYPE_IDENTIFIER ENUM LBRACE enumItemLst RBRACE
   public static boolean enumDef(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "enumDef")) return false;
     boolean r;
@@ -1002,10 +1002,10 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // specifierLst?
+  // qualifierLst?
   private static boolean enumDef_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "enumDef_0")) return false;
-    specifierLst(b, l + 1);
+    qualifierLst(b, l + 1);
     return true;
   }
 
@@ -1353,6 +1353,44 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
+  // topLevelDefAttr? qualifierLst? FORWARD TYPE TYPE_IDENTIFIER (STRUCT | INTERFACE) SEMICOLON
+  public static boolean forwardDecl(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "forwardDecl")) return false;
+    boolean r;
+    Marker m = enter_section_(b, l, _NONE_, FORWARD_DECL, "<forward decl>");
+    r = forwardDecl_0(b, l + 1);
+    r = r && forwardDecl_1(b, l + 1);
+    r = r && consumeTokens(b, 0, FORWARD, TYPE, TYPE_IDENTIFIER);
+    r = r && forwardDecl_5(b, l + 1);
+    r = r && consumeToken(b, SEMICOLON);
+    exit_section_(b, l, m, r, false, null);
+    return r;
+  }
+
+  // topLevelDefAttr?
+  private static boolean forwardDecl_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "forwardDecl_0")) return false;
+    topLevelDefAttr(b, l + 1);
+    return true;
+  }
+
+  // qualifierLst?
+  private static boolean forwardDecl_1(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "forwardDecl_1")) return false;
+    qualifierLst(b, l + 1);
+    return true;
+  }
+
+  // STRUCT | INTERFACE
+  private static boolean forwardDecl_5(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "forwardDecl_5")) return false;
+    boolean r;
+    r = consumeToken(b, STRUCT);
+    if (!r) r = consumeToken(b, INTERFACE);
+    return r;
+  }
+
+  /* ********************************************************** */
   // (IDENTIFIER SCOPE_ACCESS)* (IDENTIFIER DOT)* identifierExpr (LESS typeLst GREATER)? LPAREN argLst? RPAREN
   public static boolean functionCall(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "functionCall")) return false;
@@ -1484,7 +1522,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // topLevelDefAttr? specifierLst? F LESS dataType GREATER functionName (LESS typeLst GREATER)? LPAREN paramLst? RPAREN stmtLst
+  // topLevelDefAttr? qualifierLst? F LESS dataType GREATER functionName (LESS typeLst GREATER)? LPAREN paramLst? RPAREN stmtLst
   public static boolean functionDef(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "functionDef")) return false;
     boolean r;
@@ -1511,10 +1549,10 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     return true;
   }
 
-  // specifierLst?
+  // qualifierLst?
   private static boolean functionDef_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "functionDef_1")) return false;
-    specifierLst(b, l + 1);
+    qualifierLst(b, l + 1);
     return true;
   }
 
@@ -1716,7 +1754,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // topLevelDefAttr? specifierLst? TYPE TYPE_IDENTIFIER (LESS typeLst GREATER)? INTERFACE LBRACE signature* RBRACE
+  // topLevelDefAttr? qualifierLst? TYPE TYPE_IDENTIFIER (LESS typeLst GREATER)? INTERFACE LBRACE signature* RBRACE
   public static boolean interfaceDef(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interfaceDef")) return false;
     boolean r;
@@ -1739,10 +1777,10 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     return true;
   }
 
-  // specifierLst?
+  // qualifierLst?
   private static boolean interfaceDef_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "interfaceDef_1")) return false;
-    specifierLst(b, l + 1);
+    qualifierLst(b, l + 1);
     return true;
   }
 
@@ -2275,7 +2313,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // topLevelDefAttr? specifierLst? P functionName (LESS typeLst GREATER)? LPAREN paramLst? RPAREN stmtLst
+  // topLevelDefAttr? qualifierLst? P functionName (LESS typeLst GREATER)? LPAREN paramLst? RPAREN stmtLst
   public static boolean procedureDef(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "procedureDef")) return false;
     boolean r;
@@ -2300,10 +2338,10 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     return true;
   }
 
-  // specifierLst?
+  // qualifierLst?
   private static boolean procedureDef_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "procedureDef_1")) return false;
-    specifierLst(b, l + 1);
+    qualifierLst(b, l + 1);
     return true;
   }
 
@@ -2331,6 +2369,39 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     if (!recursion_guard_(b, l, "procedureDef_6")) return false;
     paramLst(b, l + 1);
     return true;
+  }
+
+  /* ********************************************************** */
+  // CONST | SIGNED | UNSIGNED | INLINE | PUBLIC | HEAP | COMPOSE
+  public static boolean qualifier(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "qualifier")) return false;
+    boolean r;
+    Marker m = enter_section_(b, l, _NONE_, QUALIFIER, "<qualifier>");
+    r = consumeToken(b, CONST);
+    if (!r) r = consumeToken(b, SIGNED);
+    if (!r) r = consumeToken(b, UNSIGNED);
+    if (!r) r = consumeToken(b, INLINE);
+    if (!r) r = consumeToken(b, PUBLIC);
+    if (!r) r = consumeToken(b, HEAP);
+    if (!r) r = consumeToken(b, COMPOSE);
+    exit_section_(b, l, m, r, false, null);
+    return r;
+  }
+
+  /* ********************************************************** */
+  // qualifier+
+  public static boolean qualifierLst(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "qualifierLst")) return false;
+    boolean r;
+    Marker m = enter_section_(b, l, _NONE_, QUALIFIER_LST, "<qualifier lst>");
+    r = qualifier(b, l + 1);
+    while (r) {
+      int c = current_position_(b);
+      if (!qualifier(b, l + 1)) break;
+      if (!empty_element_parsed_guard_(b, "qualifierLst", c)) break;
+    }
+    exit_section_(b, l, m, r, false, null);
+    return r;
   }
 
   /* ********************************************************** */
@@ -2440,7 +2511,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // specifierLst? (F LESS dataType GREATER | P) IDENTIFIER (LESS typeLst GREATER)? LPAREN typeLst? RPAREN SEMICOLON
+  // qualifierLst? (F LESS dataType GREATER | P) IDENTIFIER (LESS typeLst GREATER)? LPAREN typeLst? RPAREN SEMICOLON
   public static boolean signature(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "signature")) return false;
     boolean r;
@@ -2456,10 +2527,10 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // specifierLst?
+  // qualifierLst?
   private static boolean signature_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "signature_0")) return false;
-    specifierLst(b, l + 1);
+    qualifierLst(b, l + 1);
     return true;
   }
 
@@ -2561,40 +2632,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // CONST | SIGNED | UNSIGNED | INLINE | PUBLIC | HEAP | COMPOSE
-  public static boolean specifier(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "specifier")) return false;
-    boolean r;
-    Marker m = enter_section_(b, l, _NONE_, SPECIFIER, "<specifier>");
-    r = consumeToken(b, CONST);
-    if (!r) r = consumeToken(b, SIGNED);
-    if (!r) r = consumeToken(b, UNSIGNED);
-    if (!r) r = consumeToken(b, INLINE);
-    if (!r) r = consumeToken(b, PUBLIC);
-    if (!r) r = consumeToken(b, HEAP);
-    if (!r) r = consumeToken(b, COMPOSE);
-    exit_section_(b, l, m, r, false, null);
-    return r;
-  }
-
-  /* ********************************************************** */
-  // specifier+
-  public static boolean specifierLst(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "specifierLst")) return false;
-    boolean r;
-    Marker m = enter_section_(b, l, _NONE_, SPECIFIER_LST, "<specifier lst>");
-    r = specifier(b, l + 1);
-    while (r) {
-      int c = current_position_(b);
-      if (!specifier(b, l + 1)) break;
-      if (!empty_element_parsed_guard_(b, "specifierLst", c)) break;
-    }
-    exit_section_(b, l, m, r, false, null);
-    return r;
-  }
-
-  /* ********************************************************** */
-  // (mainFunctionDef | functionDef | procedureDef | structDef | interfaceDef | enumDef | genericTypeDef | aliasDef | globalVarDef | importDef | extDecl | modAttr | docCom | lineCom | blockCom)*
+  // (mainFunctionDef | functionDef | procedureDef | structDef | interfaceDef | enumDef | genericTypeDef | aliasDef | globalVarDef | importDef | extDecl | forwardDecl | modAttr | docCom | lineCom | blockCom)*
   static boolean spiceFile(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "spiceFile")) return false;
     while (true) {
@@ -2605,7 +2643,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     return true;
   }
 
-  // mainFunctionDef | functionDef | procedureDef | structDef | interfaceDef | enumDef | genericTypeDef | aliasDef | globalVarDef | importDef | extDecl | modAttr | docCom | lineCom | blockCom
+  // mainFunctionDef | functionDef | procedureDef | structDef | interfaceDef | enumDef | genericTypeDef | aliasDef | globalVarDef | importDef | extDecl | forwardDecl | modAttr | docCom | lineCom | blockCom
   private static boolean spiceFile_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "spiceFile_0")) return false;
     boolean r;
@@ -2620,6 +2658,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     if (!r) r = globalVarDef(b, l + 1);
     if (!r) r = importDef(b, l + 1);
     if (!r) r = extDecl(b, l + 1);
+    if (!r) r = forwardDecl(b, l + 1);
     if (!r) r = modAttr(b, l + 1);
     if (!r) r = docCom(b, l + 1);
     if (!r) r = lineCom(b, l + 1);
@@ -2695,7 +2734,7 @@ public class SpiceParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // topLevelDefAttr? specifierLst? TYPE TYPE_IDENTIFIER (LESS typeLst GREATER)? STRUCT (COLON typeLst)? LBRACE field* RBRACE
+  // topLevelDefAttr? qualifierLst? TYPE TYPE_IDENTIFIER (LESS typeLst GREATER)? STRUCT (COLON typeLst)? LBRACE field* RBRACE
   public static boolean structDef(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "structDef")) return false;
     boolean r;
@@ -2720,10 +2759,10 @@ public class SpiceParser implements PsiParser, LightPsiParser {
     return true;
   }
 
-  // specifierLst?
+  // qualifierLst?
   private static boolean structDef_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "structDef_1")) return false;
-    specifierLst(b, l + 1);
+    qualifierLst(b, l + 1);
     return true;
   }
 

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceDataType.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceDataType.java
@@ -11,6 +11,6 @@ public interface SpiceDataType extends PsiElement {
   SpiceBaseDataType getBaseDataType();
 
   @Nullable
-  SpiceSpecifierLst getSpecifierLst();
+  SpiceQualifierLst getQualifierLst();
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceEnumDef.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceEnumDef.java
@@ -11,6 +11,6 @@ public interface SpiceEnumDef extends PsiElement {
   SpiceEnumItemLst getEnumItemLst();
 
   @Nullable
-  SpiceSpecifierLst getSpecifierLst();
+  SpiceQualifierLst getQualifierLst();
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceForwardDecl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceForwardDecl.java
@@ -5,12 +5,12 @@ import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
-public interface SpiceAliasDef extends PsiElement {
-
-  @NotNull
-  SpiceDataType getDataType();
+public interface SpiceForwardDecl extends PsiElement {
 
   @Nullable
   SpiceQualifierLst getQualifierLst();
+
+  @Nullable
+  SpiceTopLevelDefAttr getTopLevelDefAttr();
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceFunctionDef.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceFunctionDef.java
@@ -17,7 +17,7 @@ public interface SpiceFunctionDef extends PsiElement {
   SpiceParamLst getParamLst();
 
   @Nullable
-  SpiceSpecifierLst getSpecifierLst();
+  SpiceQualifierLst getQualifierLst();
 
   @NotNull
   SpiceStmtLst getStmtLst();

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceInterfaceDef.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceInterfaceDef.java
@@ -7,11 +7,11 @@ import com.intellij.psi.PsiElement;
 
 public interface SpiceInterfaceDef extends PsiElement {
 
+  @Nullable
+  SpiceQualifierLst getQualifierLst();
+
   @NotNull
   List<SpiceSignature> getSignatureList();
-
-  @Nullable
-  SpiceSpecifierLst getSpecifierLst();
 
   @Nullable
   SpiceTopLevelDefAttr getTopLevelDefAttr();

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceProcedureDef.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceProcedureDef.java
@@ -14,7 +14,7 @@ public interface SpiceProcedureDef extends PsiElement {
   SpiceParamLst getParamLst();
 
   @Nullable
-  SpiceSpecifierLst getSpecifierLst();
+  SpiceQualifierLst getQualifierLst();
 
   @NotNull
   SpiceStmtLst getStmtLst();

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceQualifier.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceQualifier.java
@@ -5,9 +5,6 @@ import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
-public interface SpiceSpecifierLst extends PsiElement {
-
-  @NotNull
-  List<SpiceSpecifier> getSpecifierList();
+public interface SpiceQualifier extends PsiElement {
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceQualifierLst.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceQualifierLst.java
@@ -5,6 +5,9 @@ import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
-public interface SpiceSpecifier extends PsiElement {
+public interface SpiceQualifierLst extends PsiElement {
+
+  @NotNull
+  List<SpiceQualifier> getQualifierList();
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceSignature.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceSignature.java
@@ -11,7 +11,7 @@ public interface SpiceSignature extends PsiElement {
   SpiceDataType getDataType();
 
   @Nullable
-  SpiceSpecifierLst getSpecifierLst();
+  SpiceQualifierLst getQualifierLst();
 
   @NotNull
   List<SpiceTypeLst> getTypeLstList();

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceStructDef.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceStructDef.java
@@ -11,7 +11,7 @@ public interface SpiceStructDef extends PsiElement {
   List<SpiceField> getFieldList();
 
   @Nullable
-  SpiceSpecifierLst getSpecifierLst();
+  SpiceQualifierLst getQualifierLst();
 
   @Nullable
   SpiceTopLevelDefAttr getTopLevelDefAttr();

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceTypes.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceTypes.java
@@ -49,6 +49,7 @@ public interface SpiceTypes {
   IElementType FIELD = new SpiceElementType("FIELD");
   IElementType FOREACH_HEAD = new SpiceElementType("FOREACH_HEAD");
   IElementType FOREACH_LOOP = new SpiceElementType("FOREACH_LOOP");
+  IElementType FORWARD_DECL = new SpiceElementType("FORWARD_DECL");
   IElementType FOR_HEAD = new SpiceElementType("FOR_HEAD");
   IElementType FOR_LOOP = new SpiceElementType("FOR_LOOP");
   IElementType FUNCTION_CALL = new SpiceElementType("FUNCTION_CALL");
@@ -79,13 +80,13 @@ public interface SpiceTypes {
   IElementType PREFIX_UNARY_EXPR = new SpiceElementType("PREFIX_UNARY_EXPR");
   IElementType PRINTF_CALL = new SpiceElementType("PRINTF_CALL");
   IElementType PROCEDURE_DEF = new SpiceElementType("PROCEDURE_DEF");
+  IElementType QUALIFIER = new SpiceElementType("QUALIFIER");
+  IElementType QUALIFIER_LST = new SpiceElementType("QUALIFIER_LST");
   IElementType RELATIONAL_EXPR = new SpiceElementType("RELATIONAL_EXPR");
   IElementType RETURN_STMT = new SpiceElementType("RETURN_STMT");
   IElementType SHIFT_EXPR = new SpiceElementType("SHIFT_EXPR");
   IElementType SIGNATURE = new SpiceElementType("SIGNATURE");
   IElementType SIZE_OF_CALL = new SpiceElementType("SIZE_OF_CALL");
-  IElementType SPECIFIER = new SpiceElementType("SPECIFIER");
-  IElementType SPECIFIER_LST = new SpiceElementType("SPECIFIER_LST");
   IElementType STMT = new SpiceElementType("STMT");
   IElementType STMT_LST = new SpiceElementType("STMT_LST");
   IElementType STRUCT_DEF = new SpiceElementType("STRUCT_DEF");
@@ -140,6 +141,7 @@ public interface SpiceTypes {
   IElementType FALSE = new SpiceTokenType("FALSE");
   IElementType FOR = new SpiceTokenType("FOR");
   IElementType FOREACH = new SpiceTokenType("FOREACH");
+  IElementType FORWARD = new SpiceTokenType("FORWARD");
   IElementType GREATER = new SpiceTokenType("GREATER");
   IElementType GREATER_EQUAL = new SpiceTokenType("GREATER_EQUAL");
   IElementType HEAP = new SpiceTokenType("HEAP");
@@ -341,6 +343,9 @@ public interface SpiceTypes {
       else if (type == FOREACH_LOOP) {
         return new SpiceForeachLoopImpl(node);
       }
+      else if (type == FORWARD_DECL) {
+        return new SpiceForwardDeclImpl(node);
+      }
       else if (type == FOR_HEAD) {
         return new SpiceForHeadImpl(node);
       }
@@ -431,6 +436,12 @@ public interface SpiceTypes {
       else if (type == PROCEDURE_DEF) {
         return new SpiceProcedureDefImpl(node);
       }
+      else if (type == QUALIFIER) {
+        return new SpiceQualifierImpl(node);
+      }
+      else if (type == QUALIFIER_LST) {
+        return new SpiceQualifierLstImpl(node);
+      }
       else if (type == RELATIONAL_EXPR) {
         return new SpiceRelationalExprImpl(node);
       }
@@ -445,12 +456,6 @@ public interface SpiceTypes {
       }
       else if (type == SIZE_OF_CALL) {
         return new SpiceSizeOfCallImpl(node);
-      }
-      else if (type == SPECIFIER) {
-        return new SpiceSpecifierImpl(node);
-      }
-      else if (type == SPECIFIER_LST) {
-        return new SpiceSpecifierLstImpl(node);
       }
       else if (type == STMT) {
         return new SpiceStmtImpl(node);

--- a/src/main/gen/com/spicelang/intellij/spice/psi/SpiceVisitor.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/SpiceVisitor.java
@@ -179,6 +179,10 @@ public class SpiceVisitor extends PsiElementVisitor {
     visitPsiElement(o);
   }
 
+  public void visitForwardDecl(@NotNull SpiceForwardDecl o) {
+    visitPsiElement(o);
+  }
+
   public void visitFunctionCall(@NotNull SpiceFunctionCall o) {
     visitPsiElement(o);
   }
@@ -291,6 +295,14 @@ public class SpiceVisitor extends PsiElementVisitor {
     visitPsiElement(o);
   }
 
+  public void visitQualifier(@NotNull SpiceQualifier o) {
+    visitPsiElement(o);
+  }
+
+  public void visitQualifierLst(@NotNull SpiceQualifierLst o) {
+    visitPsiElement(o);
+  }
+
   public void visitRelationalExpr(@NotNull SpiceRelationalExpr o) {
     visitPsiElement(o);
   }
@@ -308,14 +320,6 @@ public class SpiceVisitor extends PsiElementVisitor {
   }
 
   public void visitSizeOfCall(@NotNull SpiceSizeOfCall o) {
-    visitPsiElement(o);
-  }
-
-  public void visitSpecifier(@NotNull SpiceSpecifier o) {
-    visitPsiElement(o);
-  }
-
-  public void visitSpecifierLst(@NotNull SpiceSpecifierLst o) {
     visitPsiElement(o);
   }
 

--- a/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceAliasDefImpl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceAliasDefImpl.java
@@ -35,8 +35,8 @@ public class SpiceAliasDefImpl extends ASTWrapperPsiElement implements SpiceAlia
 
   @Override
   @Nullable
-  public SpiceSpecifierLst getSpecifierLst() {
-    return findChildByClass(SpiceSpecifierLst.class);
+  public SpiceQualifierLst getQualifierLst() {
+    return findChildByClass(SpiceQualifierLst.class);
   }
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceDataTypeImpl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceDataTypeImpl.java
@@ -35,8 +35,8 @@ public class SpiceDataTypeImpl extends ASTWrapperPsiElement implements SpiceData
 
   @Override
   @Nullable
-  public SpiceSpecifierLst getSpecifierLst() {
-    return findChildByClass(SpiceSpecifierLst.class);
+  public SpiceQualifierLst getQualifierLst() {
+    return findChildByClass(SpiceQualifierLst.class);
   }
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceEnumDefImpl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceEnumDefImpl.java
@@ -35,8 +35,8 @@ public class SpiceEnumDefImpl extends ASTWrapperPsiElement implements SpiceEnumD
 
   @Override
   @Nullable
-  public SpiceSpecifierLst getSpecifierLst() {
-    return findChildByClass(SpiceSpecifierLst.class);
+  public SpiceQualifierLst getQualifierLst() {
+    return findChildByClass(SpiceQualifierLst.class);
   }
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceForwardDeclImpl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceForwardDeclImpl.java
@@ -11,26 +11,20 @@ import static com.spicelang.intellij.spice.psi.SpiceTypes.*;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.spicelang.intellij.spice.psi.*;
 
-public class SpiceStructDefImpl extends ASTWrapperPsiElement implements SpiceStructDef {
+public class SpiceForwardDeclImpl extends ASTWrapperPsiElement implements SpiceForwardDecl {
 
-  public SpiceStructDefImpl(@NotNull ASTNode node) {
+  public SpiceForwardDeclImpl(@NotNull ASTNode node) {
     super(node);
   }
 
   public void accept(@NotNull SpiceVisitor visitor) {
-    visitor.visitStructDef(this);
+    visitor.visitForwardDecl(this);
   }
 
   @Override
   public void accept(@NotNull PsiElementVisitor visitor) {
     if (visitor instanceof SpiceVisitor) accept((SpiceVisitor)visitor);
     else super.accept(visitor);
-  }
-
-  @Override
-  @NotNull
-  public List<SpiceField> getFieldList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, SpiceField.class);
   }
 
   @Override
@@ -43,12 +37,6 @@ public class SpiceStructDefImpl extends ASTWrapperPsiElement implements SpiceStr
   @Nullable
   public SpiceTopLevelDefAttr getTopLevelDefAttr() {
     return findChildByClass(SpiceTopLevelDefAttr.class);
-  }
-
-  @Override
-  @NotNull
-  public List<SpiceTypeLst> getTypeLstList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, SpiceTypeLst.class);
   }
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceFunctionDefImpl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceFunctionDefImpl.java
@@ -47,8 +47,8 @@ public class SpiceFunctionDefImpl extends ASTWrapperPsiElement implements SpiceF
 
   @Override
   @Nullable
-  public SpiceSpecifierLst getSpecifierLst() {
-    return findChildByClass(SpiceSpecifierLst.class);
+  public SpiceQualifierLst getQualifierLst() {
+    return findChildByClass(SpiceQualifierLst.class);
   }
 
   @Override

--- a/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceInterfaceDefImpl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceInterfaceDefImpl.java
@@ -28,15 +28,15 @@ public class SpiceInterfaceDefImpl extends ASTWrapperPsiElement implements Spice
   }
 
   @Override
-  @NotNull
-  public List<SpiceSignature> getSignatureList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, SpiceSignature.class);
+  @Nullable
+  public SpiceQualifierLst getQualifierLst() {
+    return findChildByClass(SpiceQualifierLst.class);
   }
 
   @Override
-  @Nullable
-  public SpiceSpecifierLst getSpecifierLst() {
-    return findChildByClass(SpiceSpecifierLst.class);
+  @NotNull
+  public List<SpiceSignature> getSignatureList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, SpiceSignature.class);
   }
 
   @Override

--- a/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceProcedureDefImpl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceProcedureDefImpl.java
@@ -41,8 +41,8 @@ public class SpiceProcedureDefImpl extends ASTWrapperPsiElement implements Spice
 
   @Override
   @Nullable
-  public SpiceSpecifierLst getSpecifierLst() {
-    return findChildByClass(SpiceSpecifierLst.class);
+  public SpiceQualifierLst getQualifierLst() {
+    return findChildByClass(SpiceQualifierLst.class);
   }
 
   @Override

--- a/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceQualifierImpl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceQualifierImpl.java
@@ -11,26 +11,20 @@ import static com.spicelang.intellij.spice.psi.SpiceTypes.*;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.spicelang.intellij.spice.psi.*;
 
-public class SpiceSpecifierLstImpl extends ASTWrapperPsiElement implements SpiceSpecifierLst {
+public class SpiceQualifierImpl extends ASTWrapperPsiElement implements SpiceQualifier {
 
-  public SpiceSpecifierLstImpl(@NotNull ASTNode node) {
+  public SpiceQualifierImpl(@NotNull ASTNode node) {
     super(node);
   }
 
   public void accept(@NotNull SpiceVisitor visitor) {
-    visitor.visitSpecifierLst(this);
+    visitor.visitQualifier(this);
   }
 
   @Override
   public void accept(@NotNull PsiElementVisitor visitor) {
     if (visitor instanceof SpiceVisitor) accept((SpiceVisitor)visitor);
     else super.accept(visitor);
-  }
-
-  @Override
-  @NotNull
-  public List<SpiceSpecifier> getSpecifierList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, SpiceSpecifier.class);
   }
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceQualifierLstImpl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceQualifierLstImpl.java
@@ -11,20 +11,26 @@ import static com.spicelang.intellij.spice.psi.SpiceTypes.*;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.spicelang.intellij.spice.psi.*;
 
-public class SpiceSpecifierImpl extends ASTWrapperPsiElement implements SpiceSpecifier {
+public class SpiceQualifierLstImpl extends ASTWrapperPsiElement implements SpiceQualifierLst {
 
-  public SpiceSpecifierImpl(@NotNull ASTNode node) {
+  public SpiceQualifierLstImpl(@NotNull ASTNode node) {
     super(node);
   }
 
   public void accept(@NotNull SpiceVisitor visitor) {
-    visitor.visitSpecifier(this);
+    visitor.visitQualifierLst(this);
   }
 
   @Override
   public void accept(@NotNull PsiElementVisitor visitor) {
     if (visitor instanceof SpiceVisitor) accept((SpiceVisitor)visitor);
     else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public List<SpiceQualifier> getQualifierList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, SpiceQualifier.class);
   }
 
 }

--- a/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceSignatureImpl.java
+++ b/src/main/gen/com/spicelang/intellij/spice/psi/impl/SpiceSignatureImpl.java
@@ -35,8 +35,8 @@ public class SpiceSignatureImpl extends ASTWrapperPsiElement implements SpiceSig
 
   @Override
   @Nullable
-  public SpiceSpecifierLst getSpecifierLst() {
-    return findChildByClass(SpiceSpecifierLst.class);
+  public SpiceQualifierLst getQualifierLst() {
+    return findChildByClass(SpiceQualifierLst.class);
   }
 
   @Override

--- a/src/main/java/com/spicelang/intellij/spice/Spice.bnf
+++ b/src/main/java/com/spicelang/intellij/spice/Spice.bnf
@@ -19,21 +19,22 @@
 }
 
 // Top level definitions and declarations
-spiceFile ::= (mainFunctionDef | functionDef | procedureDef | structDef | interfaceDef | enumDef | genericTypeDef | aliasDef | globalVarDef | importDef | extDecl | modAttr | docCom | lineCom | blockCom)*
+spiceFile ::= (mainFunctionDef | functionDef | procedureDef | structDef | interfaceDef | enumDef | genericTypeDef | aliasDef | globalVarDef | importDef | extDecl | forwardDecl | modAttr | docCom | lineCom | blockCom)*
 docCom ::= DOC_COMMENT
 lineCom ::= LINE_COMMENT
 blockCom ::= BLOCK_COMMENT
 mainFunctionDef ::= topLevelDefAttr? F LESS TYPE_INT GREATER MAIN LPAREN paramLst? RPAREN stmtLst
-functionDef ::= topLevelDefAttr? specifierLst? F LESS dataType GREATER functionName (LESS typeLst GREATER)? LPAREN paramLst? RPAREN stmtLst
-procedureDef ::= topLevelDefAttr? specifierLst? P functionName (LESS typeLst GREATER)? LPAREN paramLst? RPAREN stmtLst
+functionDef ::= topLevelDefAttr? qualifierLst? F LESS dataType GREATER functionName (LESS typeLst GREATER)? LPAREN paramLst? RPAREN stmtLst
+procedureDef ::= topLevelDefAttr? qualifierLst? P functionName (LESS typeLst GREATER)? LPAREN paramLst? RPAREN stmtLst
 functionName ::= (TYPE_IDENTIFIER DOT)? IDENTIFIER | OPERATOR overloadableOp
-structDef ::= topLevelDefAttr? specifierLst? TYPE TYPE_IDENTIFIER (LESS typeLst GREATER)? STRUCT (COLON typeLst)? LBRACE field* RBRACE
-interfaceDef ::= topLevelDefAttr? specifierLst? TYPE TYPE_IDENTIFIER (LESS typeLst GREATER)? INTERFACE LBRACE signature* RBRACE
-enumDef ::= specifierLst? TYPE TYPE_IDENTIFIER ENUM LBRACE enumItemLst RBRACE
+structDef ::= topLevelDefAttr? qualifierLst? TYPE TYPE_IDENTIFIER (LESS typeLst GREATER)? STRUCT (COLON typeLst)? LBRACE field* RBRACE
+interfaceDef ::= topLevelDefAttr? qualifierLst? TYPE TYPE_IDENTIFIER (LESS typeLst GREATER)? INTERFACE LBRACE signature* RBRACE
+enumDef ::= qualifierLst? TYPE TYPE_IDENTIFIER ENUM LBRACE enumItemLst RBRACE
 genericTypeDef ::= TYPE TYPE_IDENTIFIER typeAltsLst SEMICOLON
-aliasDef ::= specifierLst? TYPE TYPE_IDENTIFIER ALIAS dataType SEMICOLON
+aliasDef ::= qualifierLst? TYPE TYPE_IDENTIFIER ALIAS dataType SEMICOLON
 globalVarDef ::= dataType TYPE_IDENTIFIER (ASSIGN MINUS? value)? SEMICOLON
 extDecl ::= topLevelDefAttr? EXT (F LESS dataType GREATER | P) (IDENTIFIER | TYPE_IDENTIFIER) LPAREN typeLstWithEllipsis? RPAREN SEMICOLON
+forwardDecl ::= topLevelDefAttr? qualifierLst? FORWARD TYPE TYPE_IDENTIFIER (STRUCT | INTERFACE) SEMICOLON
 importDef ::= IMPORT STRING_LIT (AS IDENTIFIER)? SEMICOLON
 
 // Control structures
@@ -61,12 +62,12 @@ argLst ::= assignExpr (COMMA assignExpr)*
 enumItemLst ::= enumItem (COMMA enumItem)*
 enumItem ::= TYPE_IDENTIFIER (ASSIGN INT_LIT)?
 field ::= dataType IDENTIFIER (ASSIGN assignExpr)?
-signature ::= specifierLst? (F LESS dataType GREATER | P) IDENTIFIER (LESS typeLst GREATER)? LPAREN typeLst? RPAREN SEMICOLON
+signature ::= qualifierLst? (F LESS dataType GREATER | P) IDENTIFIER (LESS typeLst GREATER)? LPAREN typeLst? RPAREN SEMICOLON
 stmt ::= (declStmt | exprStmt | returnStmt | breakStmt | continueStmt | fallthroughStmt) SEMICOLON
 declStmt ::= dataType IDENTIFIER (ASSIGN assignExpr)?
 exprStmt ::= assignExpr
-specifierLst ::= specifier+
-specifier ::= CONST | SIGNED | UNSIGNED | INLINE | PUBLIC | HEAP | COMPOSE
+qualifierLst ::= qualifier+
+qualifier ::= CONST | SIGNED | UNSIGNED | INLINE | PUBLIC | HEAP | COMPOSE
 modAttr ::= MOD_ATTR_PREAMBLE LBRACKET attrLst RBRACKET
 topLevelDefAttr ::= TOPLEVEL_ATTR_PREAMBLE LBRACKET attrLst RBRACKET
 lambdaAttr ::= LBRACKET LBRACKET attrLst RBRACKET RBRACKET
@@ -118,7 +119,7 @@ lambdaProc ::= P LPAREN paramLst? RPAREN lambdaAttr? stmtLst
 lambdaExpr ::= LPAREN paramLst? RPAREN ARROW assignExpr
 
 // Types
-dataType ::= specifierLst? baseDataType (MUL | BITWISE_AND | LBRACKET (INT_LIT | TYPE_IDENTIFIER)? RBRACKET)*
+dataType ::= qualifierLst? baseDataType (MUL | BITWISE_AND | LBRACKET (INT_LIT | TYPE_IDENTIFIER)? RBRACKET)*
 baseDataType ::= TYPE_DOUBLE | TYPE_INT | TYPE_SHORT | TYPE_LONG | TYPE_BYTE | TYPE_CHAR | TYPE_STRING | TYPE_BOOL | TYPE_DYN | customDataType | functionDataType
 customDataType ::= (IDENTIFIER SCOPE_ACCESS)* TYPE_IDENTIFIER (LESS typeLst GREATER)?
 functionDataType ::= (P | F LESS dataType GREATER) LPAREN typeLst? RPAREN

--- a/src/main/java/com/spicelang/intellij/spice/Spice.flex
+++ b/src/main/java/com/spicelang/intellij/spice/Spice.flex
@@ -92,6 +92,7 @@ panic                                             { return SpiceTypes.PANIC; }
 syscall                                           { return SpiceTypes.SYSCALL; }
 cast                                              { return SpiceTypes.CAST; }
 ext                                               { return SpiceTypes.EXT; }
+forward                                           { return SpiceTypes.FORWARD; }
 true                                              { return SpiceTypes.TRUE; }
 false                                             { return SpiceTypes.FALSE; }
 {IDENTIFIER}                                      { return SpiceTypes.IDENTIFIER; }

--- a/src/main/java/com/spicelang/intellij/spice/SpiceSyntaxHighlighter.java
+++ b/src/main/java/com/spicelang/intellij/spice/SpiceSyntaxHighlighter.java
@@ -123,6 +123,7 @@ public class SpiceSyntaxHighlighter extends SyntaxHighlighterBase {
         if (tokenType.equals(SpiceTypes.SYSCALL)) return BUILTIN_KEY;
         if (tokenType.equals(SpiceTypes.CAST)) return KEYWORD_KEY;
         if (tokenType.equals(SpiceTypes.EXT)) return KEYWORD_KEY;
+        if (tokenType.equals(SpiceTypes.FORWARD)) return KEYWORD_KEY;
         if (tokenType.equals(SpiceTypes.TRUE)) return CONSTANT_KEY;
         if (tokenType.equals(SpiceTypes.FALSE)) return CONSTANT_KEY;
         if (tokenType.equals(SpiceTypes.IDENTIFIER)) return IDENTIFIER_KEY;


### PR DESCRIPTION
## Summary
- Add grammar and PSI support for forward declarations in the Spice language
- Rename `Specifier`/`SpecifierLst` to `Qualifier`/`QualifierLst` across the generated PSI and BNF grammar
- Regenerate the lexer and parser from the updated `Spice.flex`/`Spice.bnf`
- Add syntax highlighting and a test-file example for forward declarations

## Test plan
- [x] Verify forward declarations parse and highlight correctly in the IDE
- [x] Confirm existing parsing of structs/interfaces/enums/aliases is unaffected by the qualifier rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)