### PR TITLE
Add Spice run configuration with environment variable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # IntelliJ Spice Changelog
 
 ## [Unreleased]
+- Add run configuration to compile and run a Spice program via the `spice` CLI
+- Allow setting environment variables in Spice run configurations
 
 ## [1.0.12]
 - Add structure view outlining functions, types and their members

--- a/src/main/java/com/spicelang/intellij/spice/run/SpiceConfigurationFactory.java
+++ b/src/main/java/com/spicelang/intellij/spice/run/SpiceConfigurationFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.run;
+
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationType;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.components.BaseState;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SpiceConfigurationFactory extends ConfigurationFactory {
+
+    protected SpiceConfigurationFactory(ConfigurationType type) {
+        super(type);
+    }
+
+    @Override
+    public @NotNull String getId() {
+        return SpiceRunConfigurationType.ID;
+    }
+
+    @NotNull
+    @Override
+    public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
+        return new SpiceRunConfiguration(project, this, "Spice");
+    }
+
+    @Nullable
+    @Override
+    public Class<? extends BaseState> getOptionsClass() {
+        return SpiceRunConfigurationOptions.class;
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/run/SpiceRunConfiguration.java
+++ b/src/main/java/com/spicelang/intellij/spice/run/SpiceRunConfiguration.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.run;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.CommandLineState;
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.configurations.RunConfigurationBase;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.configurations.RuntimeConfigurationException;
+import com.intellij.execution.configuration.EnvironmentVariablesData;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessTerminatedListener;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.execution.ParametersListUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+
+public class SpiceRunConfiguration extends RunConfigurationBase<SpiceRunConfigurationOptions> {
+
+    protected SpiceRunConfiguration(@NotNull Project project, @NotNull ConfigurationFactory factory, String name) {
+        super(project, factory, name);
+    }
+
+    @NotNull
+    @Override
+    protected SpiceRunConfigurationOptions getOptions() {
+        return (SpiceRunConfigurationOptions) super.getOptions();
+    }
+
+    public String getSpiceExecutablePath() {
+        return getOptions().getSpiceExecutablePath();
+    }
+
+    public void setSpiceExecutablePath(String path) {
+        getOptions().setSpiceExecutablePath(path);
+    }
+
+    public String getSourceFilePath() {
+        return getOptions().getSourceFilePath();
+    }
+
+    public void setSourceFilePath(String path) {
+        getOptions().setSourceFilePath(path);
+    }
+
+    public String getProgramArguments() {
+        return getOptions().getProgramArguments();
+    }
+
+    public void setProgramArguments(String arguments) {
+        getOptions().setProgramArguments(arguments);
+    }
+
+    public EnvironmentVariablesData getEnvironmentVariables() {
+        return EnvironmentVariablesData.create(
+                getOptions().getEnvironmentVariables(),
+                getOptions().isPassParentEnvironmentVariables());
+    }
+
+    public void setEnvironmentVariables(EnvironmentVariablesData environmentVariables) {
+        getOptions().setEnvironmentVariables(environmentVariables.getEnvs());
+        getOptions().setPassParentEnvironmentVariables(environmentVariables.isPassParentEnvs());
+    }
+
+    @NotNull
+    @Override
+    public SettingsEditor<? extends RunConfiguration> getConfigurationEditor() {
+        return new SpiceSettingsEditor();
+    }
+
+    @Override
+    public void checkConfiguration() throws RuntimeConfigurationException {
+        if (StringUtil.isEmptyOrSpaces(getSpiceExecutablePath())) {
+            throw new RuntimeConfigurationException("No Spice executable specified");
+        }
+        if (StringUtil.isEmptyOrSpaces(getSourceFilePath())) {
+            throw new RuntimeConfigurationException("No Spice source file specified");
+        }
+    }
+
+    @Nullable
+    @Override
+    public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) {
+        return new CommandLineState(environment) {
+            @NotNull
+            @Override
+            protected ProcessHandler startProcess() throws ExecutionException {
+                String executable = StringUtil.defaultIfEmpty(getSpiceExecutablePath(), "spice");
+                GeneralCommandLine commandLine = new GeneralCommandLine(executable, "run");
+
+                String sourceFilePath = getSourceFilePath();
+                if (!StringUtil.isEmptyOrSpaces(sourceFilePath)) {
+                    commandLine.addParameter(sourceFilePath);
+
+                    File parentDir = new File(sourceFilePath).getParentFile();
+                    if (parentDir != null && parentDir.isDirectory()) {
+                        commandLine.setWorkDirectory(parentDir);
+                    }
+                }
+
+                String programArguments = getProgramArguments();
+                if (!StringUtil.isEmptyOrSpaces(programArguments)) {
+                    commandLine.addParameters(ParametersListUtil.parse(programArguments));
+                }
+
+                getEnvironmentVariables().configureCommandLine(commandLine, false);
+
+                commandLine.withCharset(java.nio.charset.StandardCharsets.UTF_8);
+
+                OSProcessHandler processHandler = new OSProcessHandler(commandLine);
+                ProcessTerminatedListener.attach(processHandler);
+                return processHandler;
+            }
+        };
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/run/SpiceRunConfigurationOptions.java
+++ b/src/main/java/com/spicelang/intellij/spice/run/SpiceRunConfigurationOptions.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.run;
+
+import com.intellij.execution.configurations.RunConfigurationOptions;
+import com.intellij.openapi.components.StoredProperty;
+
+import java.util.Map;
+
+public class SpiceRunConfigurationOptions extends RunConfigurationOptions {
+
+    private final StoredProperty<String> spiceExecutablePath =
+            string("spice").provideDelegate(this, "spiceExecutablePath");
+    private final StoredProperty<String> sourceFilePath =
+            string("").provideDelegate(this, "sourceFilePath");
+    private final StoredProperty<String> programArguments =
+            string("").provideDelegate(this, "programArguments");
+    private final StoredProperty<Map<String, String>> environmentVariables =
+            this.<String, String>linkedMap().provideDelegate(this, "environmentVariables");
+    private final StoredProperty<Boolean> passParentEnvironmentVariables =
+            property(true).provideDelegate(this, "passParentEnvironmentVariables");
+
+    public String getSpiceExecutablePath() {
+        return spiceExecutablePath.getValue(this);
+    }
+
+    public void setSpiceExecutablePath(String value) {
+        spiceExecutablePath.setValue(this, value);
+    }
+
+    public String getSourceFilePath() {
+        return sourceFilePath.getValue(this);
+    }
+
+    public void setSourceFilePath(String value) {
+        sourceFilePath.setValue(this, value);
+    }
+
+    public String getProgramArguments() {
+        return programArguments.getValue(this);
+    }
+
+    public void setProgramArguments(String value) {
+        programArguments.setValue(this, value);
+    }
+
+    public Map<String, String> getEnvironmentVariables() {
+        return environmentVariables.getValue(this);
+    }
+
+    public void setEnvironmentVariables(Map<String, String> value) {
+        environmentVariables.setValue(this, value);
+    }
+
+    public boolean isPassParentEnvironmentVariables() {
+        return passParentEnvironmentVariables.getValue(this);
+    }
+
+    public void setPassParentEnvironmentVariables(boolean value) {
+        passParentEnvironmentVariables.setValue(this, value);
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/run/SpiceRunConfigurationProducer.java
+++ b/src/main/java/com/spicelang/intellij/spice/run/SpiceRunConfigurationProducer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.run;
+
+import com.intellij.execution.actions.ConfigurationContext;
+import com.intellij.execution.actions.LazyRunConfigurationProducer;
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.openapi.util.Ref;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.spicelang.intellij.spice.psi.SpiceFile;
+import org.jetbrains.annotations.NotNull;
+
+public class SpiceRunConfigurationProducer extends LazyRunConfigurationProducer<SpiceRunConfiguration> {
+
+    @NotNull
+    @Override
+    public ConfigurationFactory getConfigurationFactory() {
+        return SpiceRunConfigurationType.getInstance().getConfigurationFactories()[0];
+    }
+
+    @Override
+    protected boolean setupConfigurationFromContext(@NotNull SpiceRunConfiguration configuration,
+                                                    @NotNull ConfigurationContext context,
+                                                    @NotNull Ref<PsiElement> sourceElement) {
+        VirtualFile file = getSpiceFile(context);
+        if (file == null) {
+            return false;
+        }
+        configuration.setSourceFilePath(file.getPath());
+        configuration.setName("Run " + file.getName());
+        return true;
+    }
+
+    @Override
+    public boolean isConfigurationFromContext(@NotNull SpiceRunConfiguration configuration,
+                                              @NotNull ConfigurationContext context) {
+        VirtualFile file = getSpiceFile(context);
+        return file != null && file.getPath().equals(configuration.getSourceFilePath());
+    }
+
+    private static VirtualFile getSpiceFile(@NotNull ConfigurationContext context) {
+        PsiElement location = context.getPsiLocation();
+        if (location == null) {
+            return null;
+        }
+        PsiFile psiFile = location.getContainingFile();
+        if (!(psiFile instanceof SpiceFile)) {
+            return null;
+        }
+        return psiFile.getVirtualFile();
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/run/SpiceRunConfigurationType.java
+++ b/src/main/java/com/spicelang/intellij/spice/run/SpiceRunConfigurationType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.run;
+
+import com.intellij.execution.configurations.ConfigurationTypeBase;
+import com.intellij.execution.configurations.ConfigurationTypeUtil;
+import com.intellij.openapi.util.NotNullLazyValue;
+import com.spicelang.intellij.spice.SpiceIcons;
+
+public class SpiceRunConfigurationType extends ConfigurationTypeBase {
+
+    static final String ID = "SpiceRunConfiguration";
+
+    public SpiceRunConfigurationType() {
+        super(ID, "Spice", "Run a Spice program",
+                NotNullLazyValue.createValue(() -> SpiceIcons.FILE));
+        addFactory(new SpiceConfigurationFactory(this));
+    }
+
+    public static SpiceRunConfigurationType getInstance() {
+        return ConfigurationTypeUtil.findConfigurationType(SpiceRunConfigurationType.class);
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/run/SpiceRunLineMarkerContributor.java
+++ b/src/main/java/com/spicelang/intellij/spice/run/SpiceRunLineMarkerContributor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.run;
+
+import com.intellij.execution.lineMarker.ExecutorAction;
+import com.intellij.execution.lineMarker.RunLineMarkerContributor;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.spicelang.intellij.spice.psi.SpiceMainFunctionDef;
+import com.spicelang.intellij.spice.psi.SpiceTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Shows a run gutter icon next to the {@code main} keyword of every main function definition.
+ */
+public class SpiceRunLineMarkerContributor extends RunLineMarkerContributor {
+
+    @Nullable
+    @Override
+    public Info getInfo(@NotNull PsiElement element) {
+        // Anchor on the `main` keyword leaf so a single icon is rendered on the signature line.
+        if (element.getNode().getElementType() != SpiceTypes.MAIN) {
+            return null;
+        }
+        if (PsiTreeUtil.getParentOfType(element, SpiceMainFunctionDef.class) == null) {
+            return null;
+        }
+
+        AnAction[] actions = ExecutorAction.getActions(0);
+        return new Info(AllIcons.RunConfigurations.TestState.Run, actions,
+                e -> "Run Spice program");
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/run/SpiceSettingsEditor.java
+++ b/src/main/java/com/spicelang/intellij/spice/run/SpiceSettingsEditor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.run;
+
+import com.intellij.execution.configuration.EnvironmentVariablesComponent;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.util.ui.FormBuilder;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class SpiceSettingsEditor extends SettingsEditor<SpiceRunConfiguration> {
+
+    private final JPanel panel;
+    private final JBTextField executableField = new JBTextField();
+    private final TextFieldWithBrowseButton sourceFileField = new TextFieldWithBrowseButton();
+    private final JBTextField argumentsField = new JBTextField();
+    private final EnvironmentVariablesComponent environmentVariablesComponent = new EnvironmentVariablesComponent();
+
+    public SpiceSettingsEditor() {
+        FileChooserDescriptor descriptor = FileChooserDescriptorFactory
+                .createSingleFileNoJarsDescriptor()
+                .withTitle("Select Spice Source File")
+                .withFileFilter(file -> "spice".equalsIgnoreCase(file.getExtension()));
+        sourceFileField.addBrowseFolderListener(null, descriptor);
+
+        panel = FormBuilder.createFormBuilder()
+                .addLabeledComponent("Spice executable", executableField)
+                .addLabeledComponent("Main source file", sourceFileField)
+                .addLabeledComponent("Program arguments", argumentsField)
+                .addComponent(environmentVariablesComponent)
+                .getPanel();
+    }
+
+    @Override
+    protected void resetEditorFrom(@NotNull SpiceRunConfiguration configuration) {
+        executableField.setText(configuration.getSpiceExecutablePath());
+        sourceFileField.setText(configuration.getSourceFilePath());
+        argumentsField.setText(configuration.getProgramArguments());
+        environmentVariablesComponent.setEnvData(configuration.getEnvironmentVariables());
+    }
+
+    @Override
+    protected void applyEditorTo(@NotNull SpiceRunConfiguration configuration) {
+        configuration.setSpiceExecutablePath(executableField.getText());
+        configuration.setSourceFilePath(sourceFileField.getText());
+        configuration.setProgramArguments(argumentsField.getText());
+        configuration.setEnvironmentVariables(environmentVariablesComponent.getEnvData());
+    }
+
+    @NotNull
+    @Override
+    protected JComponent createEditor() {
+        return panel;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -69,6 +69,13 @@
                 implementation="com.spicelang.intellij.spice.SpiceChooseByNameContributor"/>
         <gotoDeclarationHandler
                 implementation="com.spicelang.intellij.spice.SpiceGotoDeclarationHandler"/>
+        <configurationType
+                implementation="com.spicelang.intellij.spice.run.SpiceRunConfigurationType"/>
+        <runConfigurationProducer
+                implementation="com.spicelang.intellij.spice.run.SpiceRunConfigurationProducer"/>
+        <runLineMarkerContributor
+                language="Spice"
+                implementationClass="com.spicelang.intellij.spice.run.SpiceRunLineMarkerContributor"/>
     </extensions>
 
     <!--<actions></actions>-->


### PR DESCRIPTION
## Summary
- Introduces a Spice **run configuration** type that compiles and runs a program through the `spice` CLI (executable path, main source file, program arguments).
- Adds **environment variable** support to the run configuration, using the IDE's standard environment variables editor (name/value pairs plus an option to inherit the system environment).
- Environment variables are applied to the launched process via `EnvironmentVariablesData.configureCommandLine(...)`.

## Implementation notes
- `SpiceRunConfigurationOptions` persists the variables as a `Map<String, String>` plus a `passParentEnvironmentVariables` flag.
- `SpiceRunConfiguration` exposes them as `EnvironmentVariablesData` and wires them into the command line.
- `SpiceSettingsEditor` adds the reusable `EnvironmentVariablesComponent` to the settings form.

## Testing
- `./gradlew compileJava` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)