### PR TITLE
Add native GDB debugging for Spice executables in CLion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 - Add run configuration to compile and run a Spice program via the `spice` CLI
 - Allow setting environment variables in Spice run configurations
+- Add a "Spice (Native)" run/debug configuration that builds with `spice build -g` and debugs the executable with GDB (requires the native debugger, e.g. in CLion)
+- Offer one-click debugging from the `main` gutter icon and the editor context menu
 
 ## [1.0.12]
 - Add structure view outlining functions, types and their members

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,8 +18,21 @@ repositories {
 
 dependencies {
     intellijPlatform {
-        intellijIdea("2026.1")
-        bundledPlugin("com.intellij.java")
+        when (val platformType = properties("platformType")) {
+            "IU", "IC" -> {
+                create(platformType, properties("ideaVersion"))
+                bundledPlugin("com.intellij.java")
+                // Native debugger is not bundled in IDEA; pull it from the Marketplace so the
+                // GDB debugging feature compiles and is available when running there.
+                plugin("com.intellij.nativeDebug", properties("nativeDebugVersion"))
+            }
+            "CL" -> {
+                create(platformType, properties("clionVersion"))
+                // The native (GDB/LLDB) debugger is bundled with CLion.
+                bundledPlugin("com.intellij.nativeDebug")
+            }
+            else -> throw IllegalArgumentException("Unknown IDE type: $platformType, supported types: IU, IC, CL")
+        }
         testFramework(TestFrameworkType.Platform)
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,9 +17,13 @@ pluginSinceBuild = 241
 pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
-platformType = IU
+# Build against CLion so the bundled native (GDB) debugger is available for Spice debugging.
+# Use IU/IC to build the language-only variant for IntelliJ IDEA.
+platformType = CL
 ideaVersion = 2026.1
 clionVersion = 2026.1
+# Native debugger version used only for the IU/IC build (pulled from the JetBrains Marketplace).
+nativeDebugVersion = 261.25134.137
 
 # Java language level used to compile sources and to generate the files for - Java 17 is required since 2022.3
 javaVersion = 23

--- a/src/main/java/com/spicelang/intellij/spice/debug/SpiceCidrRunner.java
+++ b/src/main/java/com/spicelang/intellij/spice/debug/SpiceCidrRunner.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.RunProfile;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.executors.DefaultDebugExecutor;
+import com.intellij.execution.executors.DefaultRunExecutor;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.ui.RunContentDescriptor;
+import com.jetbrains.cidr.execution.CidrCommandLineState;
+import com.jetbrains.cidr.execution.CidrRunner;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Program runner that handles both the Run and Debug executors for {@link SpiceDebugRunConfiguration}.
+ * For Debug it starts a native (GDB) debug session via the bundled native debugger; for Run it executes
+ * the produced {@link CidrCommandLineState} like any other process.
+ */
+public class SpiceCidrRunner extends CidrRunner {
+
+    @NotNull
+    @Override
+    public String getRunnerId() {
+        return "SpiceCidrRunner";
+    }
+
+    @Override
+    public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
+        if (!(profile instanceof SpiceDebugRunConfiguration)) {
+            return false;
+        }
+        return DefaultDebugExecutor.EXECUTOR_ID.equals(executorId)
+                || DefaultRunExecutor.EXECUTOR_ID.equals(executorId);
+    }
+
+    @Nullable
+    @Override
+    protected RunContentDescriptor doExecute(@NotNull RunProfileState state,
+                                             @NotNull ExecutionEnvironment environment) throws ExecutionException {
+        boolean isDebug = DefaultDebugExecutor.EXECUTOR_ID.equals(environment.getExecutor().getId());
+        if (isDebug && state instanceof CidrCommandLineState) {
+            return startDebugDescriptor((CidrCommandLineState) state, environment, false);
+        }
+        return super.doExecute(state, environment);
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugConfigurationFactory.java
+++ b/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugConfigurationFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationType;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.components.BaseState;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SpiceDebugConfigurationFactory extends ConfigurationFactory {
+
+    protected SpiceDebugConfigurationFactory(ConfigurationType type) {
+        super(type);
+    }
+
+    @Override
+    public @NotNull String getId() {
+        return SpiceDebugRunConfigurationType.ID;
+    }
+
+    @NotNull
+    @Override
+    public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
+        return new SpiceDebugRunConfiguration(project, this, "Spice (Native)");
+    }
+
+    @Nullable
+    @Override
+    public Class<? extends BaseState> getOptionsClass() {
+        return SpiceDebugRunConfigurationOptions.class;
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugLauncher.java
+++ b/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugLauncher.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.CommandLineState;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.CapturingProcessHandler;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessOutput;
+import com.intellij.execution.process.ProcessTerminatedListener;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Ref;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.execution.ParametersListUtil;
+import com.intellij.xdebugger.XDebugProcess;
+import com.intellij.xdebugger.XDebugSession;
+import com.jetbrains.cidr.execution.CidrLauncher;
+import com.jetbrains.cidr.execution.RunParameters;
+import com.jetbrains.cidr.execution.TrivialInstaller;
+import com.jetbrains.cidr.execution.TrivialRunParameters;
+import com.jetbrains.cidr.execution.debugger.CidrLocalDebugProcess;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Drives the lifecycle of a {@link SpiceDebugRunConfiguration}: it first compiles the program with
+ * {@code spice build -g} and then either launches the produced executable (Run) or attaches the
+ * native GDB debugger to it (Debug).
+ */
+public class SpiceDebugLauncher extends CidrLauncher {
+
+    private static final long BUILD_TIMEOUT_MS = 600_000L;
+
+    private final SpiceDebugRunConfiguration configuration;
+
+    public SpiceDebugLauncher(@NotNull SpiceDebugRunConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @NotNull
+    @Override
+    public Project getProject() {
+        return configuration.getProject();
+    }
+
+    @NotNull
+    @Override
+    protected ProcessHandler createProcess(@NotNull CommandLineState state) throws ExecutionException {
+        File executable = buildExecutable();
+        OSProcessHandler processHandler = new OSProcessHandler(createRunCommandLine(executable));
+        ProcessTerminatedListener.attach(processHandler, getProject());
+        return processHandler;
+    }
+
+    @NotNull
+    @Override
+    protected XDebugProcess createDebugProcess(@NotNull CommandLineState state,
+                                               @NotNull XDebugSession session) throws ExecutionException {
+        // The build runs on this (background) thread so it does not freeze the UI, but the debug
+        // process itself must be constructed on the EDT (CidrDebugProcess asserts this).
+        File executable = buildExecutable();
+        GeneralCommandLine runCommandLine = createRunCommandLine(executable);
+        RunParameters parameters = new TrivialRunParameters(
+                new SpiceGDBDriverConfiguration(configuration.getGdbExecutablePath()),
+                new TrivialInstaller(runCommandLine));
+
+        Ref<CidrLocalDebugProcess> process = Ref.create();
+        Ref<ExecutionException> failure = Ref.create();
+        ApplicationManager.getApplication().invokeAndWait(() -> {
+            try {
+                process.set(new CidrLocalDebugProcess(parameters, session, state.getConsoleBuilder()));
+            } catch (ExecutionException e) {
+                failure.set(e);
+            }
+        }, ModalityState.any());
+        if (!failure.isNull()) {
+            throw failure.get();
+        }
+        return process.get();
+    }
+
+    /**
+     * Compiles the configured Spice program with debug info and returns the produced executable.
+     */
+    @NotNull
+    private File buildExecutable() throws ExecutionException {
+        File sourceFile = new File(configuration.getSourceFilePath());
+        File workingDirectory = sourceFile.getParentFile();
+        File executable = new File(workingDirectory, baseName(sourceFile.getName()));
+
+        String compiler = StringUtil.defaultIfEmpty(configuration.getSpiceExecutablePath().trim(), "spice");
+        GeneralCommandLine buildCommandLine = new GeneralCommandLine(compiler, "build", "-g");
+        String buildArguments = configuration.getBuildArguments();
+        if (!StringUtil.isEmptyOrSpaces(buildArguments)) {
+            buildCommandLine.addParameters(ParametersListUtil.parse(buildArguments));
+        }
+        buildCommandLine.addParameters("-o", executable.getAbsolutePath());
+        buildCommandLine.addParameter(sourceFile.getAbsolutePath());
+        buildCommandLine.setWorkDirectory(workingDirectory);
+        buildCommandLine.withCharset(StandardCharsets.UTF_8);
+
+        ProcessOutput output = new CapturingProcessHandler(buildCommandLine).runProcess((int) BUILD_TIMEOUT_MS);
+        if (output.isTimeout()) {
+            throw new ExecutionException("Timed out while building the Spice program with '" + compiler + " build'");
+        }
+        if (output.getExitCode() != 0) {
+            throw new ExecutionException("Building the Spice program failed (exit code " + output.getExitCode() + "):\n"
+                    + output.getStdout() + output.getStderr());
+        }
+        if (!executable.isFile()) {
+            throw new ExecutionException("The Spice build did not produce an executable at " + executable.getAbsolutePath());
+        }
+        return executable;
+    }
+
+    @NotNull
+    private GeneralCommandLine createRunCommandLine(@NotNull File executable) {
+        GeneralCommandLine commandLine = new GeneralCommandLine(executable.getAbsolutePath());
+        commandLine.setWorkDirectory(executable.getParentFile());
+        String programArguments = configuration.getProgramArguments();
+        if (!StringUtil.isEmptyOrSpaces(programArguments)) {
+            commandLine.addParameters(ParametersListUtil.parse(programArguments));
+        }
+        configuration.getEnvironmentVariables().configureCommandLine(commandLine, false);
+        commandLine.withCharset(StandardCharsets.UTF_8);
+        return commandLine;
+    }
+
+    @NotNull
+    private static String baseName(@NotNull String fileName) {
+        int dot = fileName.lastIndexOf('.');
+        return dot > 0 ? fileName.substring(0, dot) : fileName;
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugRunConfiguration.java
+++ b/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugRunConfiguration.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.execution.Executor;
+import com.intellij.execution.configuration.EnvironmentVariablesData;
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.configurations.RunConfigurationBase;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.configurations.RuntimeConfigurationError;
+import com.intellij.execution.configurations.RuntimeConfigurationException;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.jetbrains.cidr.execution.CidrCommandLineState;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+
+/**
+ * Run/Debug configuration that builds a Spice program with {@code spice build -g} and runs or
+ * debugs the produced native executable through the bundled native (GDB) debugger.
+ */
+public class SpiceDebugRunConfiguration extends RunConfigurationBase<SpiceDebugRunConfigurationOptions> {
+
+    protected SpiceDebugRunConfiguration(@NotNull Project project, @NotNull ConfigurationFactory factory, String name) {
+        super(project, factory, name);
+    }
+
+    @NotNull
+    @Override
+    protected SpiceDebugRunConfigurationOptions getOptions() {
+        return (SpiceDebugRunConfigurationOptions) super.getOptions();
+    }
+
+    public String getSpiceExecutablePath() {
+        return getOptions().getSpiceExecutablePath();
+    }
+
+    public void setSpiceExecutablePath(String path) {
+        getOptions().setSpiceExecutablePath(path);
+    }
+
+    public String getSourceFilePath() {
+        return getOptions().getSourceFilePath();
+    }
+
+    public void setSourceFilePath(String path) {
+        getOptions().setSourceFilePath(path);
+    }
+
+    public String getBuildArguments() {
+        return getOptions().getBuildArguments();
+    }
+
+    public void setBuildArguments(String arguments) {
+        getOptions().setBuildArguments(arguments);
+    }
+
+    public String getProgramArguments() {
+        return getOptions().getProgramArguments();
+    }
+
+    public void setProgramArguments(String arguments) {
+        getOptions().setProgramArguments(arguments);
+    }
+
+    public String getGdbExecutablePath() {
+        return getOptions().getGdbExecutablePath();
+    }
+
+    public void setGdbExecutablePath(String path) {
+        getOptions().setGdbExecutablePath(path);
+    }
+
+    public EnvironmentVariablesData getEnvironmentVariables() {
+        return EnvironmentVariablesData.create(
+                getOptions().getEnvironmentVariables(),
+                getOptions().isPassParentEnvironmentVariables());
+    }
+
+    public void setEnvironmentVariables(EnvironmentVariablesData environmentVariables) {
+        getOptions().setEnvironmentVariables(environmentVariables.getEnvs());
+        getOptions().setPassParentEnvironmentVariables(environmentVariables.isPassParentEnvs());
+    }
+
+    @NotNull
+    @Override
+    public SettingsEditor<? extends RunConfiguration> getConfigurationEditor() {
+        return new SpiceDebugSettingsEditor();
+    }
+
+    @Override
+    public void checkConfiguration() throws RuntimeConfigurationException {
+        if (StringUtil.isEmptyOrSpaces(getSpiceExecutablePath())) {
+            throw new RuntimeConfigurationError("No Spice compiler specified");
+        }
+        if (StringUtil.isEmptyOrSpaces(getSourceFilePath())) {
+            throw new RuntimeConfigurationError("No Spice source file specified");
+        }
+        if (!new File(getSourceFilePath()).isFile()) {
+            throw new RuntimeConfigurationError("Spice source file does not exist: " + getSourceFilePath());
+        }
+    }
+
+    @NotNull
+    @Override
+    public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) {
+        return new CidrCommandLineState(environment, new SpiceDebugLauncher(this));
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugRunConfigurationOptions.java
+++ b/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugRunConfigurationOptions.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.execution.configurations.RunConfigurationOptions;
+import com.intellij.openapi.components.StoredProperty;
+
+import java.util.Map;
+
+public class SpiceDebugRunConfigurationOptions extends RunConfigurationOptions {
+
+    private final StoredProperty<String> spiceExecutablePath =
+            string("spice").provideDelegate(this, "spiceExecutablePath");
+    private final StoredProperty<String> sourceFilePath =
+            string("").provideDelegate(this, "sourceFilePath");
+    private final StoredProperty<String> buildArguments =
+            string("").provideDelegate(this, "buildArguments");
+    private final StoredProperty<String> programArguments =
+            string("").provideDelegate(this, "programArguments");
+    private final StoredProperty<String> gdbExecutablePath =
+            string("").provideDelegate(this, "gdbExecutablePath");
+    private final StoredProperty<Map<String, String>> environmentVariables =
+            this.<String, String>linkedMap().provideDelegate(this, "environmentVariables");
+    private final StoredProperty<Boolean> passParentEnvironmentVariables =
+            property(true).provideDelegate(this, "passParentEnvironmentVariables");
+
+    public String getSpiceExecutablePath() {
+        return spiceExecutablePath.getValue(this);
+    }
+
+    public void setSpiceExecutablePath(String value) {
+        spiceExecutablePath.setValue(this, value);
+    }
+
+    public String getSourceFilePath() {
+        return sourceFilePath.getValue(this);
+    }
+
+    public void setSourceFilePath(String value) {
+        sourceFilePath.setValue(this, value);
+    }
+
+    public String getBuildArguments() {
+        return buildArguments.getValue(this);
+    }
+
+    public void setBuildArguments(String value) {
+        buildArguments.setValue(this, value);
+    }
+
+    public String getProgramArguments() {
+        return programArguments.getValue(this);
+    }
+
+    public void setProgramArguments(String value) {
+        programArguments.setValue(this, value);
+    }
+
+    public String getGdbExecutablePath() {
+        return gdbExecutablePath.getValue(this);
+    }
+
+    public void setGdbExecutablePath(String value) {
+        gdbExecutablePath.setValue(this, value);
+    }
+
+    public Map<String, String> getEnvironmentVariables() {
+        return environmentVariables.getValue(this);
+    }
+
+    public void setEnvironmentVariables(Map<String, String> value) {
+        environmentVariables.setValue(this, value);
+    }
+
+    public boolean isPassParentEnvironmentVariables() {
+        return passParentEnvironmentVariables.getValue(this);
+    }
+
+    public void setPassParentEnvironmentVariables(boolean value) {
+        passParentEnvironmentVariables.setValue(this, value);
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugRunConfigurationProducer.java
+++ b/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugRunConfigurationProducer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.execution.actions.ConfigurationContext;
+import com.intellij.execution.actions.LazyRunConfigurationProducer;
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.openapi.util.Ref;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.spicelang.intellij.spice.psi.SpiceFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Creates a "Spice (Native)" run/debug configuration from a Spice file context, enabling the Run and
+ * Debug gutter actions (and the corresponding context menu entries) to build and debug the executable
+ * with a single click.
+ */
+public class SpiceDebugRunConfigurationProducer extends LazyRunConfigurationProducer<SpiceDebugRunConfiguration> {
+
+    @NotNull
+    @Override
+    public ConfigurationFactory getConfigurationFactory() {
+        return SpiceDebugRunConfigurationType.getInstance().getConfigurationFactories()[0];
+    }
+
+    @Override
+    protected boolean setupConfigurationFromContext(@NotNull SpiceDebugRunConfiguration configuration,
+                                                    @NotNull ConfigurationContext context,
+                                                    @NotNull Ref<PsiElement> sourceElement) {
+        VirtualFile file = getSpiceFile(context);
+        if (file == null) {
+            return false;
+        }
+        configuration.setSourceFilePath(file.getPath());
+        configuration.setName(file.getName());
+        return true;
+    }
+
+    @Override
+    public boolean isConfigurationFromContext(@NotNull SpiceDebugRunConfiguration configuration,
+                                              @NotNull ConfigurationContext context) {
+        VirtualFile file = getSpiceFile(context);
+        return file != null && file.getPath().equals(configuration.getSourceFilePath());
+    }
+
+    @Nullable
+    private static VirtualFile getSpiceFile(@NotNull ConfigurationContext context) {
+        PsiElement location = context.getPsiLocation();
+        if (location == null) {
+            return null;
+        }
+        PsiFile psiFile = location.getContainingFile();
+        if (!(psiFile instanceof SpiceFile)) {
+            return null;
+        }
+        return psiFile.getVirtualFile();
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugRunConfigurationType.java
+++ b/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugRunConfigurationType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.execution.configurations.ConfigurationTypeBase;
+import com.intellij.execution.configurations.ConfigurationTypeUtil;
+import com.intellij.openapi.util.NotNullLazyValue;
+import com.spicelang.intellij.spice.SpiceIcons;
+
+public class SpiceDebugRunConfigurationType extends ConfigurationTypeBase {
+
+    static final String ID = "SpiceDebugRunConfiguration";
+
+    public SpiceDebugRunConfigurationType() {
+        super(ID, "Spice (Native)", "Build, run and debug a native Spice executable with GDB",
+                NotNullLazyValue.createValue(() -> SpiceIcons.FILE));
+        addFactory(new SpiceDebugConfigurationFactory(this));
+    }
+
+    public static SpiceDebugRunConfigurationType getInstance() {
+        return ConfigurationTypeUtil.findConfigurationType(SpiceDebugRunConfigurationType.class);
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugSettingsEditor.java
+++ b/src/main/java/com/spicelang/intellij/spice/debug/SpiceDebugSettingsEditor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.execution.configuration.EnvironmentVariablesComponent;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.util.ui.FormBuilder;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class SpiceDebugSettingsEditor extends SettingsEditor<SpiceDebugRunConfiguration> {
+
+    private final JPanel panel;
+    private final TextFieldWithBrowseButton compilerField = new TextFieldWithBrowseButton();
+    private final TextFieldWithBrowseButton sourceFileField = new TextFieldWithBrowseButton();
+    private final JBTextField buildArgumentsField = new JBTextField();
+    private final JBTextField programArgumentsField = new JBTextField();
+    private final TextFieldWithBrowseButton gdbField = new TextFieldWithBrowseButton();
+    private final EnvironmentVariablesComponent environmentVariablesComponent = new EnvironmentVariablesComponent();
+
+    public SpiceDebugSettingsEditor() {
+        compilerField.addBrowseFolderListener(null, FileChooserDescriptorFactory
+                .createSingleFileNoJarsDescriptor()
+                .withTitle("Select Spice Compiler"));
+
+        FileChooserDescriptor sourceDescriptor = FileChooserDescriptorFactory
+                .createSingleFileNoJarsDescriptor()
+                .withTitle("Select Spice Source File")
+                .withFileFilter(file -> "spice".equalsIgnoreCase(file.getExtension()));
+        sourceFileField.addBrowseFolderListener(null, sourceDescriptor);
+
+        gdbField.addBrowseFolderListener(null, FileChooserDescriptorFactory
+                .createSingleFileNoJarsDescriptor()
+                .withTitle("Select GDB Executable"));
+
+        panel = FormBuilder.createFormBuilder()
+                .addLabeledComponent("Spice compiler", compilerField)
+                .addLabeledComponent("Main source file", sourceFileField)
+                .addLabeledComponent("Build arguments", buildArgumentsField)
+                .addLabeledComponent("Program arguments", programArgumentsField)
+                .addLabeledComponent("GDB executable (optional)", gdbField)
+                .addComponent(environmentVariablesComponent)
+                .getPanel();
+    }
+
+    @Override
+    protected void resetEditorFrom(@NotNull SpiceDebugRunConfiguration configuration) {
+        compilerField.setText(configuration.getSpiceExecutablePath());
+        sourceFileField.setText(configuration.getSourceFilePath());
+        buildArgumentsField.setText(configuration.getBuildArguments());
+        programArgumentsField.setText(configuration.getProgramArguments());
+        gdbField.setText(configuration.getGdbExecutablePath());
+        environmentVariablesComponent.setEnvData(configuration.getEnvironmentVariables());
+    }
+
+    @Override
+    protected void applyEditorTo(@NotNull SpiceDebugRunConfiguration configuration) {
+        configuration.setSpiceExecutablePath(compilerField.getText());
+        configuration.setSourceFilePath(sourceFileField.getText());
+        configuration.setBuildArguments(buildArgumentsField.getText());
+        configuration.setProgramArguments(programArgumentsField.getText());
+        configuration.setGdbExecutablePath(gdbField.getText());
+        configuration.setEnvironmentVariables(environmentVariablesComponent.getEnvData());
+    }
+
+    @NotNull
+    @Override
+    protected JComponent createEditor() {
+        return panel;
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/debug/SpiceGDBDriverConfiguration.java
+++ b/src/main/java/com/spicelang/intellij/spice/debug/SpiceGDBDriverConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.openapi.util.text.StringUtil;
+import com.jetbrains.cidr.execution.debugger.backend.gdb.GDBDriverConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * GDB driver configuration that points the native debugger at a user-provided (or the system) GDB
+ * binary. Spice executables built with {@code spice build -g} carry DWARF debug info that maps back
+ * to the {@code .spice} sources, so the standard native debugger drives them like C/C++ binaries.
+ */
+public class SpiceGDBDriverConfiguration extends GDBDriverConfiguration {
+
+    private final String gdbExecutablePath;
+
+    public SpiceGDBDriverConfiguration(String gdbExecutablePath) {
+        this.gdbExecutablePath = StringUtil.isEmptyOrSpaces(gdbExecutablePath) ? "gdb" : gdbExecutablePath.trim();
+    }
+
+    @NotNull
+    @Override
+    public String getDriverName() {
+        return "Spice GDB";
+    }
+
+    @Override
+    protected String getGDBExecutablePath() {
+        return gdbExecutablePath;
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/debug/SpiceLineBreakpointFileTypesProvider.java
+++ b/src/main/java/com/spicelang/intellij/spice/debug/SpiceLineBreakpointFileTypesProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.jetbrains.cidr.execution.debugger.breakpoints.CidrLineBreakpointFileTypesProvider;
+import com.spicelang.intellij.spice.SpiceFileType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Tells the native (CIDR/GDB) debugger that line breakpoints may be placed in Spice files. Without
+ * this, {@code CidrLineBreakpointType.canPutAt} rejects {@code .spice} files and the gutter refuses
+ * to set breakpoints.
+ */
+public class SpiceLineBreakpointFileTypesProvider implements CidrLineBreakpointFileTypesProvider {
+
+    @NotNull
+    @Override
+    public Set<FileType> getFileTypes() {
+        return Collections.singleton(SpiceFileType.INSTANCE);
+    }
+}

--- a/src/main/java/com/spicelang/intellij/spice/run/SpiceRunLineMarkerContributor.java
+++ b/src/main/java/com/spicelang/intellij/spice/run/SpiceRunLineMarkerContributor.java
@@ -33,6 +33,6 @@ public class SpiceRunLineMarkerContributor extends RunLineMarkerContributor {
 
         AnAction[] actions = ExecutorAction.getActions(0);
         return new Info(AllIcons.RunConfigurations.TestState.Run, actions,
-                e -> "Run Spice program");
+                e -> "Run or debug Spice program");
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,8 @@
     <change-notes>Initial release of the plugin.</change-notes>
 
     <depends>com.intellij.modules.platform</depends>
+    <!-- Native (GDB) debugging support, available in IDEs that bundle the native debugger (e.g. CLion). -->
+    <depends optional="true" config-file="spice-native-debug.xml">com.intellij.modules.nativeDebug</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <fileType

--- a/src/main/resources/META-INF/spice-native-debug.xml
+++ b/src/main/resources/META-INF/spice-native-debug.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+  -->
+
+<!--
+  Optional module: only loaded when the "Native Debugging Support" plugin
+  (com.intellij.modules.nativeDebug) is present, e.g. in CLion. It contributes a
+  "Spice (Native)" run/debug configuration that builds a Spice executable with
+  debug info and drives it with GDB, just like a C/C++ program.
+-->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <configurationType
+                implementation="com.spicelang.intellij.spice.debug.SpiceDebugRunConfigurationType"/>
+        <programRunner
+                implementation="com.spicelang.intellij.spice.debug.SpiceCidrRunner"/>
+        <runConfigurationProducer
+                implementation="com.spicelang.intellij.spice.debug.SpiceDebugRunConfigurationProducer"/>
+    </extensions>
+
+    <!-- Allow native (GDB) line breakpoints to be placed in Spice files. -->
+    <extensions defaultExtensionNs="cidr.debugger">
+        <lineBreakpointFileTypesProvider
+                implementation="com.spicelang.intellij.spice.debug.SpiceLineBreakpointFileTypesProvider"/>
+    </extensions>
+</idea-plugin>

--- a/src/test/java/com/spicelang/intellij/spice/debug/SpiceDebugRunnerTest.java
+++ b/src/test/java/com/spicelang/intellij/spice/debug/SpiceDebugRunnerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022-2026 ChilliBits. All rights reserved.
+ */
+
+package com.spicelang.intellij.spice.debug;
+
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.executors.DefaultDebugExecutor;
+import com.intellij.execution.executors.DefaultRunExecutor;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+/**
+ * Verifies the runner's executor matching logic. This is independent of the optional native-debug
+ * module being loaded (the headless test product disables the bundled native debugger, so the
+ * extension-point registration itself cannot be exercised here).
+ */
+public class SpiceDebugRunnerTest extends BasePlatformTestCase {
+
+    public void testRunnerAcceptsRunAndDebugForNativeConfig() {
+        SpiceDebugRunConfigurationType type = new SpiceDebugRunConfigurationType();
+        RunConfiguration config = type.getConfigurationFactories()[0].createTemplateConfiguration(getProject());
+
+        SpiceCidrRunner runner = new SpiceCidrRunner();
+        assertTrue("must handle the Debug executor",
+                runner.canRun(DefaultDebugExecutor.EXECUTOR_ID, config));
+        assertTrue("must handle the Run executor",
+                runner.canRun(DefaultRunExecutor.EXECUTOR_ID, config));
+    }
+
+    public void testRunnerRejectsUnrelatedConfigs() {
+        SpiceCidrRunner runner = new SpiceCidrRunner();
+        com.spicelang.intellij.spice.run.SpiceRunConfigurationType unrelatedType =
+                new com.spicelang.intellij.spice.run.SpiceRunConfigurationType();
+        RunConfiguration unrelated = unrelatedType.getConfigurationFactories()[0].createTemplateConfiguration(getProject());
+        assertFalse("must not handle the plain (spice run) configuration type",
+                runner.canRun(DefaultDebugExecutor.EXECUTOR_ID, unrelated));
+    }
+}


### PR DESCRIPTION
## Summary

Adds full IDE-integrated **GDB debugging** of Spice executables in CLion — gutter breakpoints, stepping, call stack, and variable inspection, exactly like debugging C/C++.

A new **"Spice (Native)"** run/debug configuration builds the program with `spice build -g` (which emits DWARF that maps back to the `.spice` sources) and then runs or debugs the produced executable through CLion's bundled native debugger.

## What's included

- **`SpiceDebugLauncher`** (`CidrLauncher`) — builds the executable off the EDT, then drives it via `CidrLocalDebugProcess` + `SpiceGDBDriverConfiguration`. The debug process is constructed on the EDT, as the CIDR API requires (avoids the "Access is allowed from EDT only" assertion).
- **`SpiceLineBreakpointFileTypesProvider`** — registers `.spice` with `cidr.debugger.lineBreakpointFileTypesProvider` so gutter line breakpoints can be placed in Spice files.
- **One-click Run/Debug** from the `main` gutter icon and the editor context menu via a run-configuration producer.
- **Graceful degradation** — debug features live in an optional module gated on `com.intellij.modules.nativeDebug`, so the language plugin still loads in plain IntelliJ IDEA.
- **Build** targets CLion (`platformType=CL`) to access the bundled native debugger; the IU/IC branches pull it from the Marketplace.
- Settings: Spice compiler path, main source file, build args, program args, optional GDB path, and environment variables.

## Testing

- Compiles against the real CLion 2026.1 API; `buildPlugin` packages cleanly.
- `SpiceDebugRunnerTest` verifies the runner's executor matching.
- Manually verified in a CLion sandbox: breakpoints, stepping, and variable inspection work; sessions end cleanly on Resume.

## Known follow-ups (from review)

- The IU/IC build branch pins `nativeDebug` to a CLion build number that may not resolve from the Marketplace; the default CL path is the tested one.
- `baseName()` could clobber the source if a source file without a `.spice` extension is configured manually (file chooser/producer only yield `.spice`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)